### PR TITLE
[feat] 토큰 기반 인증 로직 & 토큰 재발급 API를 구현한다

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ springDependencyManagementVersion=1.1.4
 ### External dependency versions ###
 queryDslVersion=5.0.0
 awspringVersion=3.1.0
-jwtTokenVersion=0.12.3
+jwtTokenVersion=0.11.5
 swaggerVersion=2.3.0
 slackApiVersion=1.36.1
 guavaVersion=33.0.0

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,17 @@
+= Koddy API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 토큰 재발급 API (RefreshToken)
+
+=== HTTP Request
+
+include::{snippets}/TokenReissueApi/Success/http-request.adoc[]
+
+=== HTTP Response
+
+include::{snippets}/TokenReissueApi/Failure/http-response.adoc[]
+include::{snippets}/TokenReissueApi/Success/http-response.adoc[]

--- a/src/main/java/com/koddy/server/auth/application/usecase/ReissueTokenUseCase.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/ReissueTokenUseCase.java
@@ -1,0 +1,34 @@
+package com.koddy.server.auth.application.usecase;
+
+import com.koddy.server.auth.application.usecase.command.ReissueTokenCommand;
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.auth.domain.service.TokenIssuer;
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.auth.utils.TokenProvider;
+import com.koddy.server.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_TOKEN;
+
+@UseCase
+@RequiredArgsConstructor
+public class ReissueTokenUseCase {
+    private final TokenProvider tokenProvider;
+    private final TokenIssuer tokenIssuer;
+
+    public AuthToken invoke(final ReissueTokenCommand command) {
+        final Long memberId = tokenProvider.getId(command.refreshToken());
+        validateMemberToken(memberId, command.refreshToken());
+        return tokenIssuer.reissueAuthorityToken(memberId);
+    }
+
+    private void validateMemberToken(final Long memberId, final String refreshToken) {
+        if (isAnonymousRefreshToken(memberId, refreshToken)) {
+            throw new AuthException(INVALID_TOKEN);
+        }
+    }
+
+    private boolean isAnonymousRefreshToken(final Long memberId, final String refreshToken) {
+        return !tokenIssuer.isMemberRefreshToken(memberId, refreshToken);
+    }
+}

--- a/src/main/java/com/koddy/server/auth/application/usecase/command/ReissueTokenCommand.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/command/ReissueTokenCommand.java
@@ -1,0 +1,6 @@
+package com.koddy.server.auth.application.usecase.command;
+
+public record ReissueTokenCommand(
+        String refreshToken
+) {
+}

--- a/src/main/java/com/koddy/server/auth/domain/model/AuthToken.java
+++ b/src/main/java/com/koddy/server/auth/domain/model/AuthToken.java
@@ -1,0 +1,7 @@
+package com.koddy.server.auth.domain.model;
+
+public record AuthToken(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/koddy/server/auth/domain/model/Authenticated.java
+++ b/src/main/java/com/koddy/server/auth/domain/model/Authenticated.java
@@ -1,0 +1,12 @@
+package com.koddy.server.auth.domain.model;
+
+import com.koddy.server.member.domain.model.RoleType;
+
+import java.util.List;
+
+public record Authenticated(
+        Long id,
+        List<RoleType> roles
+) {
+    public static final String SESSION_KEY = "Koddy";
+}

--- a/src/main/java/com/koddy/server/auth/domain/model/Token.java
+++ b/src/main/java/com/koddy/server/auth/domain/model/Token.java
@@ -1,0 +1,30 @@
+package com.koddy.server.auth.domain.model;
+
+import com.koddy.server.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "member_token")
+public class Token extends BaseEntity<Token> {
+    @Column(name = "member_id", nullable = false, unique = true)
+    private Long memberId;
+
+    @Column(name = "refresh_token", nullable = false, unique = true)
+    private String refreshToken;
+
+    public Token(final Long memberId, final String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateRefreshToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/koddy/server/auth/domain/model/TokenType.java
+++ b/src/main/java/com/koddy/server/auth/domain/model/TokenType.java
@@ -1,0 +1,5 @@
+package com.koddy.server.auth.domain.model;
+
+public enum TokenType {
+    ACCESS, REFRESH
+}

--- a/src/main/java/com/koddy/server/auth/domain/repository/TokenRepository.java
+++ b/src/main/java/com/koddy/server/auth/domain/repository/TokenRepository.java
@@ -1,0 +1,32 @@
+package com.koddy.server.auth.domain.repository;
+
+import com.koddy.server.auth.domain.model.Token;
+import com.koddy.server.global.annotation.KoddyWritableTransactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    // @Query
+    @KoddyWritableTransactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+            UPDATE Token t
+            SET t.refreshToken = :refreshToken
+            WHERE t.memberId = :memberId
+            """)
+    void updateRefreshToken(@Param("memberId") Long memberId, @Param("refreshToken") String refreshToken);
+
+    @KoddyWritableTransactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM Token t WHERE t.memberId = :memberId")
+    void deleteRefreshToken(@Param("memberId") Long memberId);
+
+    // Query Method
+    Optional<Token> findByMemberId(Long memberId);
+
+    boolean existsByMemberIdAndRefreshToken(Long memberId, String refreshToken);
+}

--- a/src/main/java/com/koddy/server/auth/domain/service/TokenIssuer.java
+++ b/src/main/java/com/koddy/server/auth/domain/service/TokenIssuer.java
@@ -1,0 +1,42 @@
+package com.koddy.server.auth.domain.service;
+
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.auth.utils.TokenProvider;
+import com.koddy.server.member.domain.model.Member;
+import com.koddy.server.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenIssuer {
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final TokenManager tokenManager;
+
+    public AuthToken provideAuthorityToken(final Long memberId) {
+        final Member member = memberRepository.getByIdWithRoles(memberId);
+        final String accessToken = tokenProvider.createAccessToken(memberId, member.getRoleTypes());
+        final String refreshToken = tokenProvider.createRefreshToken(memberId);
+        tokenManager.synchronizeRefreshToken(memberId, refreshToken);
+
+        return new AuthToken(accessToken, refreshToken);
+    }
+
+    public AuthToken reissueAuthorityToken(final Long memberId) {
+        final Member member = memberRepository.getByIdWithRoles(memberId);
+        final String newAccessToken = tokenProvider.createAccessToken(memberId, member.getRoleTypes());
+        final String newRefreshToken = tokenProvider.createRefreshToken(memberId);
+        tokenManager.updateRefreshToken(memberId, newRefreshToken);
+
+        return new AuthToken(newAccessToken, newRefreshToken);
+    }
+
+    public boolean isMemberRefreshToken(final Long memberId, final String refreshToken) {
+        return tokenManager.isMemberRefreshToken(memberId, refreshToken);
+    }
+
+    public void deleteRefreshToken(final Long memberId) {
+        tokenManager.deleteRefreshToken(memberId);
+    }
+}

--- a/src/main/java/com/koddy/server/auth/domain/service/TokenManager.java
+++ b/src/main/java/com/koddy/server/auth/domain/service/TokenManager.java
@@ -1,0 +1,34 @@
+package com.koddy.server.auth.domain.service;
+
+import com.koddy.server.auth.domain.model.Token;
+import com.koddy.server.auth.domain.repository.TokenRepository;
+import com.koddy.server.global.annotation.KoddyWritableTransactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenManager {
+    private final TokenRepository tokenRepository;
+
+    @KoddyWritableTransactional
+    public void synchronizeRefreshToken(final Long memberId, final String refreshToken) {
+        tokenRepository.findByMemberId(memberId)
+                .ifPresentOrElse(
+                        token -> token.updateRefreshToken(refreshToken),
+                        () -> tokenRepository.save(new Token(memberId, refreshToken))
+                );
+    }
+
+    public void updateRefreshToken(final Long memberId, final String newRefreshToken) {
+        tokenRepository.updateRefreshToken(memberId, newRefreshToken);
+    }
+
+    public void deleteRefreshToken(final Long memberId) {
+        tokenRepository.deleteRefreshToken(memberId);
+    }
+
+    public boolean isMemberRefreshToken(final Long memberId, final String refreshToken) {
+        return tokenRepository.existsByMemberIdAndRefreshToken(memberId, refreshToken);
+    }
+}

--- a/src/main/java/com/koddy/server/auth/exception/AuthException.java
+++ b/src/main/java/com/koddy/server/auth/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.koddy.server.auth.exception;
+
+import com.koddy.server.global.base.KoddyException;
+import com.koddy.server.global.base.KoddyExceptionCode;
+
+public class AuthException extends KoddyException {
+    private final AuthExceptionCode code;
+
+    public AuthException(final AuthExceptionCode code) {
+        super(code);
+        this.code = code;
+    }
+
+    @Override
+    public KoddyExceptionCode getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/koddy/server/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/com/koddy/server/auth/exception/AuthExceptionCode.java
@@ -11,8 +11,9 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @Getter
 @RequiredArgsConstructor
 public enum AuthExceptionCode implements KoddyExceptionCode {
-    INVALID_TOKEN(UNAUTHORIZED, "AUTH_001", "토큰이 유효하지 않습니다."),
-    INVALID_PERMISSION(FORBIDDEN, "AUTH_002", "권한이 없습니다."),
+    AUTH_REQUIRED(UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
+    INVALID_PERMISSION(FORBIDDEN, "AUTH_003", "권한이 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/koddy/server/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/com/koddy/server/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,21 @@
+package com.koddy.server.auth.exception;
+
+import com.koddy.server.global.base.KoddyExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthExceptionCode implements KoddyExceptionCode {
+    INVALID_TOKEN(UNAUTHORIZED, "AUTH_001", "토큰이 유효하지 않습니다."),
+    INVALID_PERMISSION(FORBIDDEN, "AUTH_002", "권한이 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/koddy/server/auth/presentation/TokenReissueApiController.java
+++ b/src/main/java/com/koddy/server/auth/presentation/TokenReissueApiController.java
@@ -1,0 +1,38 @@
+package com.koddy.server.auth.presentation;
+
+import com.koddy.server.auth.application.usecase.ReissueTokenUseCase;
+import com.koddy.server.auth.application.usecase.command.ReissueTokenCommand;
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.auth.utils.TokenResponseWriter;
+import com.koddy.server.global.annotation.ExtractToken;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.koddy.server.auth.domain.model.TokenType.REFRESH;
+
+@Tag(name = "토큰 재발급 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token/reissue")
+public class TokenReissueApiController {
+    private final ReissueTokenUseCase reissueTokenUseCase;
+    private final TokenResponseWriter tokenResponseWriter;
+
+    @Operation(summary = "RefreshToken을 통한 토큰 재발급 Endpoint")
+    @PostMapping
+    public ResponseEntity<Void> reissueToken(
+            @ExtractToken(tokenType = REFRESH) final String refreshToken,
+            final HttpServletResponse response
+    ) {
+        final AuthToken authToken = reissueTokenUseCase.invoke(new ReissueTokenCommand(refreshToken));
+        tokenResponseWriter.applyToken(response, authToken);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/koddy/server/auth/utils/RequestTokenExtractor.java
+++ b/src/main/java/com/koddy/server/auth/utils/RequestTokenExtractor.java
@@ -1,0 +1,54 @@
+package com.koddy.server.auth.utils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.koddy.server.auth.utils.TokenResponseWriter.COOKIE_REFRESH_TOKEN;
+import static com.koddy.server.auth.utils.TokenResponseWriter.HEADER_ACCESS_TOKEN_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RequestTokenExtractor {
+    public static Optional<String> extractAccessToken(final HttpServletRequest request) {
+        final String token = request.getHeader(AUTHORIZATION);
+        if (isEmptyToken(token)) {
+            return Optional.empty();
+        }
+        return checkToken(token.split(" "));
+    }
+
+    public static Optional<String> extractRefreshToken(final HttpServletRequest request) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return Optional.empty();
+        }
+
+        final String token = Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(COOKIE_REFRESH_TOKEN))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+
+        if (isEmptyToken(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(token);
+    }
+
+    private static boolean isEmptyToken(final String token) {
+        return !StringUtils.hasText(token);
+    }
+
+    private static Optional<String> checkToken(final String[] parts) {
+        if (parts.length == 2 && parts[0].equals(HEADER_ACCESS_TOKEN_PREFIX)) {
+            return Optional.ofNullable(parts[1]);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/koddy/server/auth/utils/TokenProvider.java
+++ b/src/main/java/com/koddy/server/auth/utils/TokenProvider.java
@@ -1,0 +1,105 @@
+package com.koddy.server.auth.utils;
+
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.member.domain.model.RoleType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_TOKEN;
+
+@Slf4j
+@Component
+public class TokenProvider {
+    private final SecretKey secretKey;
+    private final long accessTokenValidityInSeconds;
+    private final long refreshTokenValidityInSeconds;
+
+    public TokenProvider(
+            @Value("${jwt.secret-key}") final String secretKey,
+            @Value("${jwt.access-token-validity-seconds}") final long accessTokenValidityInSeconds,
+            @Value("${jwt.refresh-token-validity-seconds}") final long refreshTokenValidityInSeconds
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityInSeconds = accessTokenValidityInSeconds;
+        this.refreshTokenValidityInSeconds = refreshTokenValidityInSeconds;
+    }
+
+    public String createAccessToken(final Long memberId, final List<RoleType> roles) {
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+        final ZonedDateTime tokenValidity = now.plusSeconds(accessTokenValidityInSeconds);
+
+        return Jwts.builder()
+                .claim("id", memberId)
+                .claim("roles", roles)
+                .issuedAt(Date.from(now.toInstant()))
+                .expiration(Date.from(tokenValidity.toInstant()))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(final Long memberId) {
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+        final ZonedDateTime tokenValidity = now.plusSeconds(refreshTokenValidityInSeconds);
+
+        return Jwts.builder()
+                .claim("id", memberId)
+                .issuedAt(Date.from(now.toInstant()))
+                .expiration(Date.from(tokenValidity.toInstant()))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public Long getId(final String token) {
+        return getClaims(token)
+                .getPayload()
+                .get("id", Long.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<RoleType> getRoles(final String token) {
+        return getClaims(token)
+                .getPayload()
+                .get("roles", List.class);
+    }
+
+    public void validateToken(final String token) {
+        try {
+            final Jws<Claims> claims = getClaims(token);
+            final Date expiredDate = claims.getPayload().getExpiration();
+            final Date now = new Date();
+
+            if (expiredDate.before(now)) {
+                throw new AuthException(INVALID_TOKEN);
+            }
+        } catch (final ExpiredJwtException |
+                       SecurityException |
+                       MalformedJwtException |
+                       UnsupportedJwtException |
+                       IllegalArgumentException e) {
+            throw new AuthException(INVALID_TOKEN);
+        }
+    }
+
+    private Jws<Claims> getClaims(final String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+    }
+}

--- a/src/main/java/com/koddy/server/auth/utils/TokenResponseWriter.java
+++ b/src/main/java/com/koddy/server/auth/utils/TokenResponseWriter.java
@@ -1,0 +1,43 @@
+package com.koddy.server.auth.utils;
+
+import com.koddy.server.auth.domain.model.AuthToken;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.boot.web.server.Cookie.SameSite.STRICT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+@Component
+public class TokenResponseWriter {
+    public static final String COOKIE_REFRESH_TOKEN = "refresh_token";
+    public static final String HEADER_ACCESS_TOKEN_PREFIX = "Bearer";
+
+    private final long refreshTokenCookieAge;
+
+    public TokenResponseWriter(@Value("${jwt.refresh-token-validity-seconds}") final long refreshTokenCookieAge) {
+        this.refreshTokenCookieAge = refreshTokenCookieAge;
+    }
+
+    public void applyToken(final HttpServletResponse response, final AuthToken token) {
+        applyAccessToken(response, token.accessToken());
+        applyRefreshToken(response, token.refreshToken());
+    }
+
+    private void applyAccessToken(final HttpServletResponse response, final String accessToken) {
+        response.setHeader(AUTHORIZATION, String.join(" ", HEADER_ACCESS_TOKEN_PREFIX, accessToken));
+    }
+
+    private void applyRefreshToken(final HttpServletResponse response, final String refreshToken) {
+        final ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN, refreshToken)
+                .maxAge(refreshTokenCookieAge)
+                .sameSite(STRICT.attributeValue())
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.setHeader(SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/com/koddy/server/global/annotation/Auth.java
+++ b/src/main/java/com/koddy/server/global/annotation/Auth.java
@@ -1,0 +1,11 @@
+package com.koddy.server.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/koddy/server/global/annotation/AuthArgumentResolver.java
+++ b/src/main/java/com/koddy/server/global/annotation/AuthArgumentResolver.java
@@ -13,7 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import static com.koddy.server.auth.domain.model.Authenticated.SESSION_KEY;
-import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_PERMISSION;
+import static com.koddy.server.auth.exception.AuthExceptionCode.AUTH_REQUIRED;
 import static com.koddy.server.auth.utils.RequestTokenExtractor.extractAccessToken;
 
 @RequiredArgsConstructor
@@ -50,7 +50,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     private String getAccessToken(final HttpServletRequest request) {
         final String accessToken = extractAccessToken(request)
-                .orElseThrow(() -> new AuthException(INVALID_PERMISSION));
+                .orElseThrow(() -> new AuthException(AUTH_REQUIRED));
         tokenProvider.validateToken(accessToken);
         return accessToken;
     }
@@ -67,7 +67,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     private void validateSessionPayload(final HttpSession session) {
         if (session == null || session.getAttribute(SESSION_KEY) == null) {
-            throw new AuthException(INVALID_PERMISSION);
+            throw new AuthException(AUTH_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/koddy/server/global/annotation/AuthArgumentResolver.java
+++ b/src/main/java/com/koddy/server/global/annotation/AuthArgumentResolver.java
@@ -1,0 +1,73 @@
+package com.koddy.server.global.annotation;
+
+import com.koddy.server.auth.domain.model.Authenticated;
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.auth.utils.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.koddy.server.auth.domain.model.Authenticated.SESSION_KEY;
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_PERMISSION;
+import static com.koddy.server.auth.utils.RequestTokenExtractor.extractAccessToken;
+
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class);
+    }
+
+    @Override
+    public Authenticated resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        // 토큰 버전
+        return getTokenPayload(webRequest);
+
+        // 세션 버전
+//        return getSessionPayload(webRequest);
+    }
+
+    /**
+     * 토큰 버전
+     */
+    private Authenticated getTokenPayload(final NativeWebRequest webRequest) {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final String accessToken = getAccessToken(request);
+        return new Authenticated(tokenProvider.getId(accessToken), tokenProvider.getRoles(accessToken));
+    }
+
+    private String getAccessToken(final HttpServletRequest request) {
+        final String accessToken = extractAccessToken(request)
+                .orElseThrow(() -> new AuthException(INVALID_PERMISSION));
+        tokenProvider.validateToken(accessToken);
+        return accessToken;
+    }
+
+    /**
+     * 세션 버전
+     */
+    private Authenticated getSessionPayload(final NativeWebRequest webRequest) {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final HttpSession session = request.getSession(false);
+        validateSessionPayload(session);
+        return (Authenticated) session.getAttribute(SESSION_KEY);
+    }
+
+    private void validateSessionPayload(final HttpSession session) {
+        if (session == null || session.getAttribute(SESSION_KEY) == null) {
+            throw new AuthException(INVALID_PERMISSION);
+        }
+    }
+}

--- a/src/main/java/com/koddy/server/global/annotation/ExtractToken.java
+++ b/src/main/java/com/koddy/server/global/annotation/ExtractToken.java
@@ -1,0 +1,14 @@
+package com.koddy.server.global.annotation;
+
+import com.koddy.server.auth.domain.model.TokenType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExtractToken {
+    TokenType tokenType() default TokenType.ACCESS;
+}

--- a/src/main/java/com/koddy/server/global/annotation/ExtractTokenArgumentResolver.java
+++ b/src/main/java/com/koddy/server/global/annotation/ExtractTokenArgumentResolver.java
@@ -1,0 +1,50 @@
+package com.koddy.server.global.annotation;
+
+import com.koddy.server.auth.domain.model.TokenType;
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.auth.utils.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_PERMISSION;
+import static com.koddy.server.auth.utils.RequestTokenExtractor.extractAccessToken;
+import static com.koddy.server.auth.utils.RequestTokenExtractor.extractRefreshToken;
+
+@RequiredArgsConstructor
+public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolver {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ExtractToken.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final ExtractToken extractToken = parameter.getParameterAnnotation(ExtractToken.class);
+
+        final String token = getToken(request, extractToken.tokenType());
+        tokenProvider.validateToken(token);
+        return token;
+    }
+
+    private String getToken(final HttpServletRequest request, final TokenType type) {
+        if (type == TokenType.ACCESS) {
+            return extractAccessToken(request)
+                    .orElseThrow(() -> new AuthException(INVALID_PERMISSION));
+        }
+        return extractRefreshToken(request)
+                .orElseThrow(() -> new AuthException(INVALID_PERMISSION));
+    }
+}

--- a/src/main/java/com/koddy/server/global/config/AdditionalWebConfig.java
+++ b/src/main/java/com/koddy/server/global/config/AdditionalWebConfig.java
@@ -1,15 +1,22 @@
 package com.koddy.server.global.config;
 
+import com.koddy.server.auth.utils.TokenProvider;
+import com.koddy.server.global.annotation.AuthArgumentResolver;
+import com.koddy.server.global.annotation.ExtractTokenArgumentResolver;
 import com.koddy.server.global.config.properties.CorsProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class AdditionalWebConfig implements WebMvcConfigurer {
     private final CorsProperties corsProperties;
+    private final TokenProvider tokenProvider;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -19,5 +26,11 @@ public class AdditionalWebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthArgumentResolver(tokenProvider));
+        resolvers.add(new ExtractTokenArgumentResolver(tokenProvider));
     }
 }

--- a/src/main/java/com/koddy/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/koddy/server/global/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.koddy.server.global.config;
 
+import com.koddy.server.global.annotation.Auth;
+import com.koddy.server.global.annotation.ExtractToken;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,10 +32,23 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
                 @Server(
                         url = "http://localhost:8080",
                         description = "Local Server"
+                ),
+                @Server(
+                        url = "https://dev:8080",
+                        description = "Dev Server"
                 )
         }
 )
 public class SwaggerConfig {
+    static {
+        SpringDocUtils
+                .getConfig()
+                .addAnnotationsToIgnore(
+                        Auth.class,
+                        ExtractToken.class
+                );
+    }
+
     @Bean
     public GroupedOpenApi studyWithMeApi() {
         return GroupedOpenApi.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,11 @@ encrypt:
   secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb # 테스트용 Secret Key
   salt: 45b24edcbc33a9d7b9d53b3c23ae70bae6f9d95e28132db3f35b920d0e466cde # 테스트용 Salt (Even Hex Number)
 
+jwt:
+  secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb # 테스트용 Secret Key
+  access-token-validity-seconds: 7200
+  refresh-token-validity-seconds: 1209600
+
 slack:
   webhook:
     url: ${SLACK_WEBHOOK_URL:slack-webhook-url}

--- a/src/main/resources/db/migration/V1__init_about_member.sql
+++ b/src/main/resources/db/migration/V1__init_about_member.sql
@@ -50,16 +50,6 @@ CREATE TABLE IF NOT EXISTS member_role
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 
-CREATE TABLE IF NOT EXISTS member_token
-(
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
-    member_id        BIGINT       NOT NULL UNIQUE,
-    refresh_token    VARCHAR(250) NOT NULL UNIQUE,
-    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4;
-
 CREATE TABLE IF NOT EXISTS mentor_chat_time
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -89,11 +79,6 @@ ALTER TABLE available_language
 
 ALTER TABLE member_role
     ADD CONSTRAINT fk_member_role_member_id_from_member
-        FOREIGN KEY (member_id)
-            REFERENCES member (id);
-
-ALTER TABLE member_token
-    ADD CONSTRAINT fk_member_token_member_id_from_member
         FOREIGN KEY (member_id)
             REFERENCES member (id);
 

--- a/src/main/resources/db/migration/V2__add_token.sql
+++ b/src/main/resources/db/migration/V2__add_token.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS member_token
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id        BIGINT       NOT NULL UNIQUE,
+    refresh_token    VARCHAR(250) NOT NULL UNIQUE,
+    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_modified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+ALTER TABLE member_token
+    ADD CONSTRAINT fk_member_token_member_id_from_member
+        FOREIGN KEY (member_id)
+            REFERENCES member (id);

--- a/src/test/java/com/koddy/server/auth/application/usecase/ReissueTokenUseCaseTest.java
+++ b/src/test/java/com/koddy/server/auth/application/usecase/ReissueTokenUseCaseTest.java
@@ -1,0 +1,73 @@
+package com.koddy.server.auth.application.usecase;
+
+import com.koddy.server.auth.application.usecase.command.ReissueTokenCommand;
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.auth.domain.service.TokenIssuer;
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.auth.utils.TokenProvider;
+import com.koddy.server.common.UseCaseTest;
+import com.koddy.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_TOKEN;
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("Auth -> ReissueTokenUseCase 테스트")
+class ReissueTokenUseCaseTest extends UseCaseTest {
+    private final TokenProvider tokenProvider = mock(TokenProvider.class);
+    private final TokenIssuer tokenIssuer = mock(TokenIssuer.class);
+    private final ReissueTokenUseCase sut = new ReissueTokenUseCase(tokenProvider, tokenIssuer);
+
+    private final Member member = MENTOR_1.toDomain().apply(1L);
+    private final ReissueTokenCommand command = new ReissueTokenCommand(REFRESH_TOKEN);
+
+    @Test
+    @DisplayName("RefreshToken이 유효하지 않으면 토큰 재발급에 실패한다")
+    void throwExceptionByInvalidRefreshToken() {
+        // given
+        given(tokenProvider.getId(command.refreshToken())).willReturn(member.getId());
+        given(tokenIssuer.isMemberRefreshToken(member.getId(), command.refreshToken())).willReturn(false);
+
+        // when - then
+        assertThatThrownBy(() -> sut.invoke(command))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.getMessage());
+
+        assertAll(
+                () -> verify(tokenProvider, times(1)).getId(command.refreshToken()),
+                () -> verify(tokenIssuer, times(1)).isMemberRefreshToken(member.getId(), command.refreshToken())
+        );
+    }
+
+    @Test
+    @DisplayName("유효성이 확인된 RefreshToken을 통해서 새로운 AccessToken과 RefreshToken을 재발급받는다")
+    void reissueSuccess() {
+        // given
+        given(tokenProvider.getId(command.refreshToken())).willReturn(member.getId());
+        given(tokenIssuer.isMemberRefreshToken(member.getId(), command.refreshToken())).willReturn(true);
+
+        final AuthToken authToken = new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN);
+        given(tokenIssuer.reissueAuthorityToken(member.getId())).willReturn(authToken);
+
+        // when
+        final AuthToken result = sut.invoke(command);
+
+        // then
+        assertAll(
+                () -> verify(tokenProvider, times(1)).getId(command.refreshToken()),
+                () -> verify(tokenIssuer, times(1)).isMemberRefreshToken(member.getId(), command.refreshToken()),
+                () -> assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(result.refreshToken()).isEqualTo(REFRESH_TOKEN)
+        );
+    }
+}

--- a/src/test/java/com/koddy/server/auth/domain/model/TokenTest.java
+++ b/src/test/java/com/koddy/server/auth/domain/model/TokenTest.java
@@ -1,0 +1,28 @@
+package com.koddy.server.auth.domain.model;
+
+import com.koddy.server.common.ParallelTest;
+import com.koddy.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Auth -> 도메인 [Token] 테스트")
+class TokenTest extends ParallelTest {
+    private final Member member = MENTOR_1.toDomain().apply(1L);
+
+    @Test
+    @DisplayName("Token을 업데이트한다")
+    void updateRefreshToken() {
+        // given
+        final Token token = new Token(member.getId(), REFRESH_TOKEN);
+
+        // when
+        token.updateRefreshToken(REFRESH_TOKEN + "_update");
+
+        // then
+        assertThat(token.getRefreshToken()).isEqualTo(REFRESH_TOKEN + "_update");
+    }
+}

--- a/src/test/java/com/koddy/server/auth/domain/repository/TokenRepositoryTest.java
+++ b/src/test/java/com/koddy/server/auth/domain/repository/TokenRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.koddy.server.auth.domain.repository;
+
+import com.koddy.server.auth.domain.model.Token;
+import com.koddy.server.common.RepositoryTest;
+import com.koddy.server.member.domain.model.Member;
+import com.koddy.server.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Auth -> TokenRepository 테스트")
+class TokenRepositoryTest extends RepositoryTest {
+    @Autowired
+    private TokenRepository sut;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(MENTOR_1.toDomain());
+    }
+
+    @Test
+    @DisplayName("사용자가 보유하고 있는 RefreshToken을 조회한다")
+    void findByMemberId() {
+        // given
+        sut.save(new Token(member.getId(), REFRESH_TOKEN));
+
+        // when
+        final Optional<Token> emptyToken = sut.findByMemberId(member.getId() + 10000L);
+        final Token findToken = sut.findByMemberId(member.getId()).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(emptyToken).isEmpty(),
+                () -> assertThat(findToken.getMemberId()).isEqualTo(member.getId()),
+                () -> assertThat(findToken.getRefreshToken()).isEqualTo(REFRESH_TOKEN)
+        );
+    }
+
+    @Test
+    @DisplayName("사용자가 보유하고 있는 RefreshToken을 재발급한다")
+    void updateRefreshToken() {
+        // given
+        sut.save(new Token(member.getId(), REFRESH_TOKEN));
+
+        // when
+        final String newRefreshToken = REFRESH_TOKEN + "reissue";
+        sut.updateRefreshToken(member.getId(), newRefreshToken);
+
+        // then
+        final Token findToken = sut.findByMemberId(member.getId()).orElseThrow();
+        assertThat(findToken.getRefreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("사용자가 보유하고 있는 RefreshToken인지 확인한다")
+    void existsByMemberIdAndRefreshToken() {
+        // given
+        sut.save(new Token(member.getId(), REFRESH_TOKEN));
+
+        // when
+        final boolean actual1 = sut.existsByMemberIdAndRefreshToken(member.getId(), REFRESH_TOKEN);
+        final boolean actual2 = sut.existsByMemberIdAndRefreshToken(member.getId(), "fake");
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("사용자가 보유하고 있는 RefreshToken을 삭제한다")
+    void deleteRefreshToken() {
+        // given
+        sut.save(new Token(member.getId(), REFRESH_TOKEN));
+        assertThat(sut.findByMemberId(member.getId())).isPresent();
+
+        // when
+        sut.deleteRefreshToken(member.getId());
+
+        // then
+        assertThat(sut.findByMemberId(member.getId())).isEmpty();
+    }
+}

--- a/src/test/java/com/koddy/server/auth/domain/service/TokenIssuerTest.java
+++ b/src/test/java/com/koddy/server/auth/domain/service/TokenIssuerTest.java
@@ -1,0 +1,73 @@
+package com.koddy.server.auth.domain.service;
+
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.auth.utils.TokenProvider;
+import com.koddy.server.common.ParallelTest;
+import com.koddy.server.member.domain.model.Member;
+import com.koddy.server.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("Auth -> TokenIssuer 테스트")
+public class TokenIssuerTest extends ParallelTest {
+    private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final TokenProvider tokenProvider = mock(TokenProvider.class);
+    private final TokenManager tokenManager = mock(TokenManager.class);
+    private final TokenIssuer sut = new TokenIssuer(memberRepository, tokenProvider, tokenManager);
+
+    private final Member member = MENTOR_1.toDomain().apply(1L);
+
+    @Test
+    @DisplayName("AuthToken[Access + Refresh]을 제공한다")
+    void provideAuthorityToken() {
+        // given
+        given(memberRepository.getByIdWithRoles(member.getId())).willReturn(member);
+        given(tokenProvider.createAccessToken(member.getId(), member.getRoleTypes())).willReturn(ACCESS_TOKEN);
+        given(tokenProvider.createRefreshToken(member.getId())).willReturn(REFRESH_TOKEN);
+
+        // when
+        final AuthToken authToken = sut.provideAuthorityToken(member.getId());
+
+        // then
+        assertAll(
+                () -> verify(memberRepository, times(1)).getByIdWithRoles(member.getId()),
+                () -> verify(tokenProvider, times(1)).createAccessToken(member.getId(), member.getRoleTypes()),
+                () -> verify(tokenProvider, times(1)).createRefreshToken(member.getId()),
+                () -> verify(tokenManager, times(1)).synchronizeRefreshToken(member.getId(), REFRESH_TOKEN),
+                () -> assertThat(authToken.accessToken()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(authToken.refreshToken()).isEqualTo(REFRESH_TOKEN)
+        );
+    }
+
+    @Test
+    @DisplayName("AuthToken[Access + Refresh]을 재발급한다")
+    void reissueAuthorityToken() {
+        // given
+        given(memberRepository.getByIdWithRoles(member.getId())).willReturn(member);
+        given(tokenProvider.createAccessToken(member.getId(), member.getRoleTypes())).willReturn(ACCESS_TOKEN);
+        given(tokenProvider.createRefreshToken(member.getId())).willReturn(REFRESH_TOKEN);
+
+        // when
+        final AuthToken authToken = sut.reissueAuthorityToken(member.getId());
+
+        // then
+        assertAll(
+                () -> verify(memberRepository, times(1)).getByIdWithRoles(member.getId()),
+                () -> verify(tokenProvider, times(1)).createAccessToken(member.getId(), member.getRoleTypes()),
+                () -> verify(tokenProvider, times(1)).createRefreshToken(member.getId()),
+                () -> verify(tokenManager, times(1)).updateRefreshToken(member.getId(), REFRESH_TOKEN),
+                () -> assertThat(authToken.accessToken()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(authToken.refreshToken()).isEqualTo(REFRESH_TOKEN)
+        );
+    }
+}

--- a/src/test/java/com/koddy/server/auth/domain/service/TokenManagerTest.java
+++ b/src/test/java/com/koddy/server/auth/domain/service/TokenManagerTest.java
@@ -1,0 +1,82 @@
+package com.koddy.server.auth.domain.service;
+
+import com.koddy.server.auth.domain.model.Token;
+import com.koddy.server.auth.domain.repository.TokenRepository;
+import com.koddy.server.common.UseCaseTest;
+import com.koddy.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("Auth -> TokenManager 테스트")
+class TokenManagerTest extends UseCaseTest {
+    private final TokenRepository tokenRepository = mock(TokenRepository.class);
+    private final TokenManager sut = new TokenManager(tokenRepository);
+
+    private final Member member = MENTOR_1.toDomain().apply(1L);
+    private final String previousToken = "previous";
+    private final String newToken = "new";
+
+    @Nested
+    @DisplayName("RefreshToken 동기화")
+    class SynchronizeRefreshToken {
+        @Test
+        @DisplayName("RefreshToken을 보유한 상태면 새로운 RefreshToken으로 대체한다")
+        void update() {
+            // given
+            final Token token = new Token(member.getId(), previousToken).apply(1L);
+            given(tokenRepository.findByMemberId(member.getId())).willReturn(Optional.of(token));
+
+            // when
+            sut.synchronizeRefreshToken(member.getId(), newToken);
+
+            // then
+            assertAll(
+                    () -> verify(tokenRepository, times(0)).save(any(Token.class)),
+                    () -> assertThat(token.getRefreshToken()).isEqualTo(newToken)
+            );
+        }
+
+        @Test
+        @DisplayName("보유한 RefreshToken이 없다면 새로 발급한다")
+        void reissue() {
+            // given
+            given(tokenRepository.findByMemberId(member.getId())).willReturn(Optional.empty());
+
+            // when
+            sut.synchronizeRefreshToken(member.getId(), newToken);
+
+            // then
+            verify(tokenRepository, times(1)).save(any(Token.class));
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 소유의 RefreshToken인지 확인한다")
+    void isMemberRefreshToken() {
+        // given
+        given(tokenRepository.existsByMemberIdAndRefreshToken(member.getId(), previousToken)).willReturn(false);
+        given(tokenRepository.existsByMemberIdAndRefreshToken(member.getId(), newToken)).willReturn(true);
+
+        // when
+        final boolean actual1 = sut.isMemberRefreshToken(member.getId(), previousToken);
+        final boolean actual2 = sut.isMemberRefreshToken(member.getId(), newToken);
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isFalse(),
+                () -> assertThat(actual2).isTrue()
+        );
+    }
+}

--- a/src/test/java/com/koddy/server/auth/presentation/TokenReissueApiControllerTest.java
+++ b/src/test/java/com/koddy/server/auth/presentation/TokenReissueApiControllerTest.java
@@ -1,0 +1,84 @@
+package com.koddy.server.auth.presentation;
+
+import com.koddy.server.auth.application.usecase.ReissueTokenUseCase;
+import com.koddy.server.auth.domain.model.AuthToken;
+import com.koddy.server.common.ControllerTest;
+import com.koddy.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.RequestBuilder;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_TOKEN;
+import static com.koddy.server.auth.utils.TokenResponseWriter.COOKIE_REFRESH_TOKEN;
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.cookie;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.header;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.createResponseSnippets;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.failureDocsWithRefreshToken;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.successDocsWithRefreshToken;
+import static com.koddy.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TokenReissueApiController.class)
+@DisplayName("Auth -> TokenReissueApiController 테스트")
+class TokenReissueApiControllerTest extends ControllerTest {
+    @MockBean
+    private ReissueTokenUseCase reissueTokenUseCase;
+
+    @Nested
+    @DisplayName("토큰 재발급 API [POST /api/token/reissue] - Required RefreshToken")
+    class ReissueToken {
+        private static final String BASE_URL = "/api/token/reissue";
+
+        @Test
+        @DisplayName("유효하지 않은 RefreshToken으로 인해 토큰 재발급에 실패한다")
+        void throwExceptionByExpiredRefreshToken() throws Exception {
+            // given
+            mockingTokenWithInvalidException();
+
+            // when
+            final RequestBuilder requestBuilder = postWithRefreshToken(BASE_URL);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isUnauthorized())
+                    .andExpectAll(getResultMatchersViaExceptionCode(INVALID_TOKEN))
+                    .andDo(failureDocsWithRefreshToken("TokenReissueApi/Failure"));
+        }
+
+        @Test
+        @DisplayName("사용자 소유의 RefreshToken을 통해서 AccessToken과 RefreshToken을 재발급받는다")
+        void success() throws Exception {
+            // given
+            final Member member = MENTOR_1.toDomain().apply(1L);
+            mockingToken(true, member.getId(), member.getRoleTypes());
+            given(reissueTokenUseCase.invoke(any())).willReturn(new AuthToken(ACCESS_TOKEN, REFRESH_TOKEN));
+
+            // when
+            final RequestBuilder requestBuilder = postWithRefreshToken(BASE_URL);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(status().isNoContent())
+                    .andDo(successDocsWithRefreshToken("TokenReissueApi/Success", createResponseSnippets(
+                            responseHeaders(
+                                    header(AUTHORIZATION, "Access Token"),
+                                    header(SET_COOKIE, "Set Refresh Token")
+                            ),
+                            responseCookies(
+                                    cookie(COOKIE_REFRESH_TOKEN, "Refresh Token")
+                            )
+                    )));
+        }
+    }
+}

--- a/src/test/java/com/koddy/server/auth/utils/RequestTokenExtractorTest.java
+++ b/src/test/java/com/koddy/server/auth/utils/RequestTokenExtractorTest.java
@@ -1,0 +1,104 @@
+package com.koddy.server.auth.utils;
+
+import com.koddy.server.common.ParallelTest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.koddy.server.auth.utils.TokenResponseWriter.COOKIE_REFRESH_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.BEARER_TOKEN;
+import static com.koddy.server.common.utils.TokenUtils.REFRESH_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@DisplayName("Auth -> RequestTokenExtractor 테스트")
+class RequestTokenExtractorTest extends ParallelTest {
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @Nested
+    @DisplayName("AccessToken 추출")
+    class ExtractAccessToken {
+        @Test
+        @DisplayName("HTTP Request Message의 Authorization Header에 토큰이 없다면 Optional 빈 값을 응답한다")
+        void emptyToken() {
+            // given
+            given(request.getHeader(AUTHORIZATION)).willReturn(null);
+
+            // when
+            final Optional<String> token = RequestTokenExtractor.extractAccessToken(request);
+
+            // then
+            assertThat(token).isEmpty();
+        }
+
+        @Test
+        @DisplayName("HTTP Request Message의 Authorization Header에 토큰 타입만 명시되었다면 Optional 빈 값을 응답한다")
+        void emptyTokenWithType() {
+            // given
+            given(request.getHeader(AUTHORIZATION)).willReturn(BEARER_TOKEN);
+
+            // when
+            final Optional<String> token = RequestTokenExtractor.extractAccessToken(request);
+
+            // then
+            assertThat(token).isEmpty();
+        }
+
+        @Test
+        @DisplayName("HTTP Request Message의 Authorization Header에 토큰이 있다면 Optional로 감싸서 응답한다")
+        void success() {
+            // given
+            given(request.getHeader(AUTHORIZATION)).willReturn(String.join(" ", BEARER_TOKEN, ACCESS_TOKEN));
+
+            // when
+            final Optional<String> token = RequestTokenExtractor.extractAccessToken(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(token).isPresent(),
+                    () -> assertThat(token.get()).isEqualTo(ACCESS_TOKEN)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("RefreshToken 추출")
+    class ExtractRefreshToken {
+        @Test
+        @DisplayName("HTTP Request Message의 Cookie에 RefreshToken이 없다면 Optional 빈 값을 응답한다")
+        void emptyToken() {
+            // given
+            given(request.getCookies()).willReturn(new Cookie[0]);
+
+            // when
+            final Optional<String> token = RequestTokenExtractor.extractRefreshToken(request);
+
+            // then
+            assertThat(token).isEmpty();
+        }
+
+        @Test
+        @DisplayName("HTTP Request Message의 Cookie에 RefreshToken이 있다면 Optional로 감싸서 응답한다")
+        void success() {
+            // given
+            given(request.getCookies()).willReturn(new Cookie[]{new Cookie(COOKIE_REFRESH_TOKEN, REFRESH_TOKEN)});
+
+            // when
+            final Optional<String> token = RequestTokenExtractor.extractRefreshToken(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(token).isPresent(),
+                    () -> assertThat(token.get()).isEqualTo(REFRESH_TOKEN)
+            );
+        }
+    }
+}

--- a/src/test/java/com/koddy/server/auth/utils/TokenProviderTest.java
+++ b/src/test/java/com/koddy/server/auth/utils/TokenProviderTest.java
@@ -1,0 +1,74 @@
+package com.koddy.server.auth.utils;
+
+import com.koddy.server.auth.exception.AuthException;
+import com.koddy.server.common.ParallelTest;
+import com.koddy.server.member.domain.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_TOKEN;
+import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("Auth -> TokenProvider 테스트")
+class TokenProviderTest extends ParallelTest {
+    private static final String SECRET_KEY = "asldfjsadlfjalksjf01jf02j9012f0120f12jf1j29v0saduf012ue101212c01";
+
+    private final TokenProvider invalidProvider = new TokenProvider(SECRET_KEY, 0L, 0L);
+    private final TokenProvider validProvider = new TokenProvider(SECRET_KEY, 7200L, 7200L);
+
+    private final Member member = MENTOR_1.toDomain().apply(1L);
+
+    @Test
+    @DisplayName("AccessToken과 RefreshToken을 발급한다")
+    void createToken() {
+        // when
+        final String accessToken = validProvider.createAccessToken(member.getId(), member.getRoleTypes());
+        final String refreshToken = validProvider.createRefreshToken(member.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(accessToken).isNotNull(),
+                () -> assertThat(refreshToken).isNotNull()
+        );
+    }
+
+    @Test
+    @DisplayName("Token의 Payload를 추출한다")
+    void extractPayload() {
+        // when
+        final String accessToken = validProvider.createAccessToken(member.getId(), member.getRoleTypes());
+
+        // then
+        assertThat(validProvider.getId(accessToken)).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("Token 만료에 대한 유효성을 검증한다")
+    void validateToken1() {
+        // when
+        final String validToken = validProvider.createAccessToken(member.getId(), member.getRoleTypes());
+        final String invalidToken = invalidProvider.createAccessToken(member.getId(), member.getRoleTypes());
+
+        // then
+        assertDoesNotThrow(() -> validProvider.validateToken(validToken));
+        assertThatThrownBy(() -> invalidProvider.validateToken(invalidToken))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("Token 조작에 대한 유효성을 검증한다")
+    void validateToken2() {
+        // when
+        final String forgedToken = validProvider.createAccessToken(member.getId(), member.getRoleTypes()) + "hacked";
+
+        // then
+        assertThatThrownBy(() -> validProvider.validateToken(forgedToken))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.getMessage());
+    }
+}

--- a/src/test/java/com/koddy/server/common/config/TestWebBeanConfiguration.java
+++ b/src/test/java/com/koddy/server/common/config/TestWebBeanConfiguration.java
@@ -1,0 +1,21 @@
+package com.koddy.server.common.config;
+
+import com.koddy.server.auth.utils.TokenResponseWriter;
+import com.koddy.server.global.config.properties.CorsProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Set;
+
+@TestConfiguration
+public class TestWebBeanConfiguration {
+    @Bean
+    public CorsProperties corsProperties() {
+        return new CorsProperties(Set.of("http://localhost:8080"));
+    }
+
+    @Bean
+    public TokenResponseWriter tokenResponseWriter() {
+        return new TokenResponseWriter(1234);
+    }
+}

--- a/src/test/java/com/koddy/server/common/utils/RestDocsSpecificationUtils.java
+++ b/src/test/java/com/koddy/server/common/utils/RestDocsSpecificationUtils.java
@@ -14,6 +14,7 @@ import org.springframework.restdocs.snippet.Snippet;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import static com.koddy.server.auth.utils.TokenResponseWriter.COOKIE_REFRESH_TOKEN;
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.cookie;
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.header;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -103,7 +104,7 @@ public class RestDocsSpecificationUtils {
 
     private static Snippet getCookieWithRefreshToken() {
         return requestCookies(
-                cookie("refresh_token", "Refresh Token")
+                cookie(COOKIE_REFRESH_TOKEN, "Refresh Token")
         );
     }
 

--- a/src/test/java/com/koddy/server/common/utils/RestDocsSpecificationUtils.java
+++ b/src/test/java/com/koddy/server/common/utils/RestDocsSpecificationUtils.java
@@ -110,7 +110,6 @@ public class RestDocsSpecificationUtils {
 
     private static Snippet getExceptionResponseFields() {
         return responseFields(
-                fieldWithPath("status").description("HTTP 상태 코드"),
                 fieldWithPath("errorCode").description("커스텀 예외 코드"),
                 fieldWithPath("message").description("예외 메시지")
         );

--- a/src/test/java/com/koddy/server/common/utils/TokenUtils.java
+++ b/src/test/java/com/koddy/server/common/utils/TokenUtils.java
@@ -2,6 +2,8 @@ package com.koddy.server.common.utils;
 
 import jakarta.servlet.http.Cookie;
 
+import static com.koddy.server.auth.utils.TokenResponseWriter.COOKIE_REFRESH_TOKEN;
+
 public class TokenUtils {
     public static final String BEARER_TOKEN = "Bearer";
     public static final String ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZXMiOlsiTUVOVE9SIiwiTUVOVEVFIl0sImlhdCI6MTcwMzc0NjI1NywiZXhwIjozMjgwNTQ2MjU3fQ.hJaFVG4SgXNoVs_6GB6yoPSTr7WO8n30LD0RSgmcyPY";
@@ -12,6 +14,6 @@ public class TokenUtils {
     }
 
     public static Cookie applyRefreshToken() {
-        return new Cookie("refresh_token", REFRESH_TOKEN);
+        return new Cookie(COOKIE_REFRESH_TOKEN, REFRESH_TOKEN);
     }
 }

--- a/src/test/java/com/koddy/server/member/domain/model/EmailTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/EmailTest.java
@@ -1,5 +1,6 @@
 package com.koddy.server.member.domain.model;
 
+import com.koddy.server.common.ParallelTest;
 import com.koddy.server.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @DisplayName("Member -> 도메인 [Email VO] 테스트")
-class EmailTest {
+class EmailTest extends ParallelTest {
     @Nested
     @DisplayName("Email 생성")
     class Construct {

--- a/src/test/java/com/koddy/server/member/domain/model/PasswordTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/PasswordTest.java
@@ -1,5 +1,6 @@
 package com.koddy.server.member.domain.model;
 
+import com.koddy.server.common.ParallelTest;
 import com.koddy.server.global.encrypt.Encryptor;
 import com.koddy.server.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Member -> 도메인 [Password VO] 테스트")
-class PasswordTest {
+class PasswordTest extends ParallelTest {
     public final Encryptor encryptor = getEncryptor();
 
     @Nested

--- a/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
@@ -1,5 +1,6 @@
 package com.koddy.server.member.domain.model.mentee;
 
+import com.koddy.server.common.ParallelTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Member/Mentee -> 도메인 [Mentee] 테스트")
-class MenteeTest {
+class MenteeTest extends ParallelTest {
     private static final String EMPTY = "EMPTY";
 
     @Test

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
@@ -1,5 +1,6 @@
 package com.koddy.server.member.domain.model.mentor;
 
+import com.koddy.server.common.ParallelTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Member/Mentor -> 도메인 [Mentor] 테스트")
-class MentorTest {
+class MentorTest extends ParallelTest {
     private static final String EMPTY = "EMPTY";
 
     @Test

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/PeriodTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/PeriodTest.java
@@ -1,5 +1,6 @@
 package com.koddy.server.member.domain.model.mentor;
 
+import com.koddy.server.common.ParallelTest;
 import com.koddy.server.member.exception.MemberException;
 import com.koddy.server.member.exception.MemberExceptionCode;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @DisplayName("Member/Mentor -> 도메인 [Period VO] 테스트")
-class PeriodTest {
+class PeriodTest extends ParallelTest {
     @Nested
     @DisplayName("Period 생성")
     class Construct {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,6 +17,11 @@ encrypt:
   secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb # 테스트용 Secret Key
   salt: 45b24edcbc33a9d7b9d53b3c23ae70bae6f9d95e28132db3f35b920d0e466cde # 테스트용 Salt (Even Hex Number)
 
+jwt:
+  secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb # 테스트용 Secret Key
+  access-token-validity-seconds: 7200
+  refresh-token-validity-seconds: 1209600
+
 slack:
   webhook:
     url: slack-webhook-url


### PR DESCRIPTION
## 📄 Summary

> Close #10

<br>

https://github.com/jwtk/jjwt/issues/873
- `io.jsonwebtoken:jjwt` v0.12.3에서 제공되는 JWT를 활용한 Parallel Testing 과정에서 Thread-Safety Issue 발생
- v0.12.3 -> v0.11.5
