### PR TITLE
[fix] 이메일 인증 시 사용자 계정 정보를 활성화시킨다

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -53,7 +53,6 @@ include::{snippets}/MemberApi/SignUp/Success/response-fields.adoc[]
 ==== HTTP Request
 
 include::{snippets}/MemberApi/EmailAuth/Send/http-request.adoc[]
-include::{snippets}/MemberApi/EmailAuth/Send/request-fields.adoc[]
 
 ==== HTTP Response
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -38,11 +38,7 @@ include::{snippets}/MemberApi/SignUp/Success/request-fields.adoc[]
 
 === HTTP Response
 
-include::{snippets}/MemberApi/SignUp/Failure/Case1/http-response.adoc[]
-include::{snippets}/MemberApi/SignUp/Failure/Case2/http-response.adoc[]
-include::{snippets}/MemberApi/SignUp/Failure/Case3/http-response.adoc[]
-include::{snippets}/MemberApi/SignUp/Failure/Case4/http-response.adoc[]
-include::{snippets}/MemberApi/SignUp/Failure/Case5/http-response.adoc[]
+include::{snippets}/MemberApi/SignUp/Failure/http-response.adoc[]
 include::{snippets}/MemberApi/SignUp/Success/http-response.adoc[]
 include::{snippets}/MemberApi/SignUp/Success/response-fields.adoc[]
 
@@ -80,7 +76,8 @@ include::{snippets}/MemberApi/Complete/Mentor/Success/request-fields.adoc[]
 
 ==== HTTP Response
 
-include::{snippets}/MemberApi/Complete/Mentor/Failure/http-response.adoc[]
+include::{snippets}/MemberApi/Complete/Mentor/Failure/Case1/http-response.adoc[]
+include::{snippets}/MemberApi/Complete/Mentor/Failure/Case2/http-response.adoc[]
 include::{snippets}/MemberApi/Complete/Mentor/Success/http-response.adoc[]
 
 === 멘티 부가정보 기입
@@ -92,7 +89,8 @@ include::{snippets}/MemberApi/Complete/Mentee/Success/request-fields.adoc[]
 
 ==== HTTP Response
 
-include::{snippets}/MemberApi/Complete/Mentee/Failure/http-response.adoc[]
+include::{snippets}/MemberApi/Complete/Mentee/Failure/Case1/http-response.adoc[]
+include::{snippets}/MemberApi/Complete/Mentee/Failure/Case2/http-response.adoc[]
 include::{snippets}/MemberApi/Complete/Mentee/Success/http-response.adoc[]
 
 == 파일 관련 API

--- a/src/main/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCase.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCase.java
@@ -4,6 +4,7 @@ import com.koddy.server.auth.application.adapter.MailAuthenticationProcessor;
 import com.koddy.server.auth.application.usecase.command.ConfirmAuthCodeCommand;
 import com.koddy.server.auth.application.usecase.command.SendAuthCodeCommand;
 import com.koddy.server.auth.domain.model.code.AuthKey;
+import com.koddy.server.global.annotation.KoddyWritableTransactional;
 import com.koddy.server.global.annotation.UseCase;
 import com.koddy.server.mail.application.adapter.EmailSender;
 import com.koddy.server.member.domain.model.Member;
@@ -25,12 +26,15 @@ public class EmailAuthenticationUseCase {
         emailSender.sendEmailAuthMail(member.getEmail().getValue(), authCode);
     }
 
+    @KoddyWritableTransactional
     public void confirmAuthCode(final ConfirmAuthCodeCommand command) {
         final Member<?> member = memberRepository.getByEmail(command.email());
 
         final String key = generateAuthKey(member.getEmail().getValue());
         mailAuthenticationProcessor.verifyAuthCode(key, command.authCode());
         mailAuthenticationProcessor.deleteAuthCode(key); // 인증 성공 후 바로 제거 (재활용 X)
+
+        member.authenticate();
     }
 
     private String generateAuthKey(final String email) {

--- a/src/main/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCase.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCase.java
@@ -19,7 +19,7 @@ public class EmailAuthenticationUseCase {
     private final EmailSender emailSender;
 
     public void sendAuthCode(final SendAuthCodeCommand command) {
-        final Member<?> member = memberRepository.getByEmail(command.email());
+        final Member<?> member = memberRepository.getById(command.memberId());
 
         final String key = generateAuthKey(member.getEmail().getValue());
         final String authCode = mailAuthenticationProcessor.storeAuthCode(key);
@@ -28,7 +28,7 @@ public class EmailAuthenticationUseCase {
 
     @KoddyWritableTransactional
     public void confirmAuthCode(final ConfirmAuthCodeCommand command) {
-        final Member<?> member = memberRepository.getByEmail(command.email());
+        final Member<?> member = memberRepository.getById(command.memberId());
 
         final String key = generateAuthKey(member.getEmail().getValue());
         mailAuthenticationProcessor.verifyAuthCode(key, command.authCode());

--- a/src/main/java/com/koddy/server/auth/application/usecase/command/ConfirmAuthCodeCommand.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/command/ConfirmAuthCodeCommand.java
@@ -1,7 +1,7 @@
 package com.koddy.server.auth.application.usecase.command;
 
 public record ConfirmAuthCodeCommand(
-        String email,
+        Long memberId,
         String authCode
 ) {
 }

--- a/src/main/java/com/koddy/server/auth/application/usecase/command/SendAuthCodeCommand.java
+++ b/src/main/java/com/koddy/server/auth/application/usecase/command/SendAuthCodeCommand.java
@@ -1,6 +1,6 @@
 package com.koddy.server.auth.application.usecase.command;
 
 public record SendAuthCodeCommand(
-        String email
+        Long memberId
 ) {
 }

--- a/src/main/java/com/koddy/server/auth/presentation/EmailAuthenticationApiController.java
+++ b/src/main/java/com/koddy/server/auth/presentation/EmailAuthenticationApiController.java
@@ -3,8 +3,9 @@ package com.koddy.server.auth.presentation;
 import com.koddy.server.auth.application.usecase.EmailAuthenticationUseCase;
 import com.koddy.server.auth.application.usecase.command.ConfirmAuthCodeCommand;
 import com.koddy.server.auth.application.usecase.command.SendAuthCodeCommand;
+import com.koddy.server.auth.domain.model.Authenticated;
 import com.koddy.server.auth.presentation.dto.request.ConfirmAuthCodeRequest;
-import com.koddy.server.auth.presentation.dto.request.SendAuthCodeRequest;
+import com.koddy.server.global.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,18 +26,22 @@ public class EmailAuthenticationApiController {
     @Operation(summary = "인증번호 발송 Endpoint")
     @PostMapping
     public ResponseEntity<Void> sendAuthCode(
-            @RequestBody @Valid final SendAuthCodeRequest request
+            @Auth final Authenticated authenticated
     ) {
-        emailAuthenticationUseCase.sendAuthCode(new SendAuthCodeCommand(request.email()));
+        emailAuthenticationUseCase.sendAuthCode(new SendAuthCodeCommand(authenticated.id()));
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "인증번호 확인 Endpoint")
     @PostMapping("/confirm")
     public ResponseEntity<Void> confirmAuthCode(
+            @Auth final Authenticated authenticated,
             @RequestBody @Valid final ConfirmAuthCodeRequest request
     ) {
-        emailAuthenticationUseCase.confirmAuthCode(new ConfirmAuthCodeCommand(request.email(), request.authCode()));
+        emailAuthenticationUseCase.confirmAuthCode(new ConfirmAuthCodeCommand(
+                authenticated.id(),
+                request.authCode()
+        ));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/koddy/server/auth/presentation/dto/request/ConfirmAuthCodeRequest.java
+++ b/src/main/java/com/koddy/server/auth/presentation/dto/request/ConfirmAuthCodeRequest.java
@@ -1,7 +1,9 @@
 package com.koddy.server.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record ConfirmAuthCodeRequest(
         @NotBlank(message = "인증 코드는 필수입니다.")
         String authCode

--- a/src/main/java/com/koddy/server/auth/presentation/dto/request/ConfirmAuthCodeRequest.java
+++ b/src/main/java/com/koddy/server/auth/presentation/dto/request/ConfirmAuthCodeRequest.java
@@ -3,9 +3,6 @@ package com.koddy.server.auth.presentation.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ConfirmAuthCodeRequest(
-        @NotBlank(message = "인증을 진행할 이메일은 필수입니다.")
-        String email,
-
         @NotBlank(message = "인증 코드는 필수입니다.")
         String authCode
 ) {

--- a/src/main/java/com/koddy/server/auth/presentation/dto/request/SendAuthCodeRequest.java
+++ b/src/main/java/com/koddy/server/auth/presentation/dto/request/SendAuthCodeRequest.java
@@ -1,9 +1,0 @@
-package com.koddy.server.auth.presentation.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record SendAuthCodeRequest(
-        @NotBlank(message = "인증을 진행할 이메일은 필수입니다.")
-        String email
-) {
-}

--- a/src/main/java/com/koddy/server/file/presentation/FileManagementApiController.java
+++ b/src/main/java/com/koddy/server/file/presentation/FileManagementApiController.java
@@ -1,4 +1,4 @@
-package com.koddy.server.file.presentation.dto;
+package com.koddy.server.file.presentation;
 
 import com.koddy.server.file.application.adapter.FileManager;
 import com.koddy.server.file.domain.model.PresignedFileData;

--- a/src/main/java/com/koddy/server/file/presentation/dto/request/GetPresignedUrlRequest.java
+++ b/src/main/java/com/koddy/server/file/presentation/dto/request/GetPresignedUrlRequest.java
@@ -1,7 +1,9 @@
 package com.koddy.server.file.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record GetPresignedUrlRequest(
         @NotBlank(message = "파일명은 필수입니다.")
         String fileName

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMenteeRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMenteeRequest.java
@@ -5,9 +5,11 @@ import com.koddy.server.member.domain.model.Nationality;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record CompleteMenteeRequest(
         @NotBlank(message = "이름은 필수입니다.")
         String name,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMenteeRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMenteeRequest.java
@@ -2,6 +2,7 @@ package com.koddy.server.member.presentation.dto.request;
 
 import com.koddy.server.member.domain.model.Language;
 import com.koddy.server.member.domain.model.Nationality;
+import com.koddy.server.member.utils.validator.ValidMailAuthenticated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,9 @@ import java.util.List;
 
 @Builder
 public record CompleteMenteeRequest(
+        @ValidMailAuthenticated
+        Boolean authenticated,
+
         @NotBlank(message = "이름은 필수입니다.")
         String name,
 

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMentorRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMentorRequest.java
@@ -7,9 +7,11 @@ import com.koddy.server.member.domain.model.mentor.Schedule;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record CompleteMentorRequest(
         @NotBlank(message = "이름은 필수입니다.")
         String name,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMentorRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/CompleteMentorRequest.java
@@ -4,6 +4,7 @@ import com.koddy.server.member.domain.model.Language;
 import com.koddy.server.member.domain.model.Nationality;
 import com.koddy.server.member.domain.model.mentor.Period;
 import com.koddy.server.member.domain.model.mentor.Schedule;
+import com.koddy.server.member.utils.validator.ValidMailAuthenticated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -13,6 +14,9 @@ import java.util.List;
 
 @Builder
 public record CompleteMentorRequest(
+        @ValidMailAuthenticated
+        Boolean authenticated,
+
         @NotBlank(message = "이름은 필수입니다.")
         String name,
 

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/EmailDuplicateCheckRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/EmailDuplicateCheckRequest.java
@@ -1,7 +1,9 @@
 package com.koddy.server.member.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record EmailDuplicateCheckRequest(
         @NotBlank(message = "중복 체크할 이메일은 필수입니다.")
         String value

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/MentorScheduleRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/MentorScheduleRequest.java
@@ -1,9 +1,11 @@
 package com.koddy.server.member.presentation.dto.request;
 
 import com.koddy.server.member.domain.model.mentor.Day;
+import lombok.Builder;
 
 import java.time.LocalTime;
 
+@Builder
 public record MentorScheduleRequest(
         Day day,
         LocalTime startTime,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/SimpleSignUpRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/SimpleSignUpRequest.java
@@ -4,7 +4,9 @@ import com.koddy.server.member.domain.model.MemberType;
 import com.koddy.server.member.utils.validator.ValidMailCheck;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record SimpleSignUpRequest(
         @NotBlank(message = "이메일은 필수입니다.")
         String email,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMenteeBasicInfoRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMenteeBasicInfoRequest.java
@@ -5,9 +5,11 @@ import com.koddy.server.member.domain.model.Nationality;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record UpdateMenteeBasicInfoRequest(
         @NotBlank(message = "이름은 필수입니다.")
         String name,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMenteePasswordRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMenteePasswordRequest.java
@@ -1,7 +1,9 @@
 package com.koddy.server.member.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateMenteePasswordRequest(
         @NotBlank(message = "기존 비밀번호는 필수입니다.")
         String currentPassword,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorBasicInfoRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorBasicInfoRequest.java
@@ -5,9 +5,11 @@ import com.koddy.server.member.domain.model.Nationality;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record UpdateMentorBasicInfoRequest(
         @NotBlank(message = "이름은 필수입니다.")
         String name,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorPasswordRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorPasswordRequest.java
@@ -1,7 +1,9 @@
 package com.koddy.server.member.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateMentorPasswordRequest(
         @NotBlank(message = "기존 비밀번호는 필수입니다.")
         String currentPassword,

--- a/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorScheduleRequest.java
+++ b/src/main/java/com/koddy/server/member/presentation/dto/request/UpdateMentorScheduleRequest.java
@@ -3,9 +3,11 @@ package com.koddy.server.member.presentation.dto.request;
 import com.koddy.server.member.domain.model.mentor.Period;
 import com.koddy.server.member.domain.model.mentor.Schedule;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record UpdateMentorScheduleRequest(
         @NotEmpty(message = "멘토링 스케줄은 하루 이상 선택해야 합니다.")
         List<MentorScheduleRequest> schedules

--- a/src/main/java/com/koddy/server/member/utils/validator/ValidMailAuthenticated.java
+++ b/src/main/java/com/koddy/server/member/utils/validator/ValidMailAuthenticated.java
@@ -1,0 +1,20 @@
+package com.koddy.server.member.utils.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidMailAuthenticatedValidator.class)
+public @interface ValidMailAuthenticated {
+    String message() default "이메일 인증을 진행해야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/koddy/server/member/utils/validator/ValidMailAuthenticatedValidator.java
+++ b/src/main/java/com/koddy/server/member/utils/validator/ValidMailAuthenticatedValidator.java
@@ -3,12 +3,12 @@ package com.koddy.server.member.utils.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class ValidMailCheckValidator implements ConstraintValidator<ValidMailCheck, Boolean> {
+public class ValidMailAuthenticatedValidator implements ConstraintValidator<ValidMailAuthenticated, Boolean> {
     @Override
     public boolean isValid(final Boolean value, final ConstraintValidatorContext context) {
         if (value == null) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("이메일 중복 확인 결과는 필수입니다.")
+            context.buildConstraintViolationWithTemplate("이메일 인증 결과는 필수입니다.")
                     .addConstraintViolation();
             return false;
         }

--- a/src/test/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCaseTest.java
+++ b/src/test/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCaseTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_AUTH_CODE;
 import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -60,7 +61,8 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
             assertAll(
                     () -> verify(memberRepository, times(1)).getByEmail(command.email()),
                     () -> verify(mailAuthenticationProcessor, times(1)).storeAuthCode(key),
-                    () -> verify(emailSender, times(1)).sendEmailAuthMail(email, authCode)
+                    () -> verify(emailSender, times(1)).sendEmailAuthMail(email, authCode),
+                    () -> assertThat(member.isAuthenticated()).isFalse()
             );
         }
     }
@@ -110,7 +112,8 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
             assertAll(
                     () -> verify(memberRepository, times(1)).getByEmail(command.email()),
                     () -> verify(mailAuthenticationProcessor, times(1)).verifyAuthCode(key, command.authCode()),
-                    () -> verify(mailAuthenticationProcessor, times(1)).deleteAuthCode(key)
+                    () -> verify(mailAuthenticationProcessor, times(1)).deleteAuthCode(key),
+                    () -> assertThat(member.isAuthenticated()).isTrue()
             );
         }
     }

--- a/src/test/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCaseTest.java
+++ b/src/test/java/com/koddy/server/auth/application/usecase/EmailAuthenticationUseCaseTest.java
@@ -7,14 +7,17 @@ import com.koddy.server.auth.domain.model.code.AuthKey;
 import com.koddy.server.auth.exception.AuthException;
 import com.koddy.server.common.UseCaseTest;
 import com.koddy.server.mail.application.adapter.EmailSender;
+import com.koddy.server.member.domain.model.Email;
 import com.koddy.server.member.domain.model.Member;
+import com.koddy.server.member.domain.model.Password;
+import com.koddy.server.member.domain.model.mentor.Mentor;
 import com.koddy.server.member.domain.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.koddy.server.auth.exception.AuthExceptionCode.INVALID_AUTH_CODE;
-import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.EncryptorFactory.getEncryptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -36,32 +39,32 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
             emailSender
     );
 
-    private final Member<?> member = MENTOR_1.toDomain().apply(1L);
+    private final Member<?> member = new Mentor(
+            Email.init("sjiwon4491@gmail.com"),
+            Password.encrypt("Koddy123!@#", getEncryptor())
+    ).apply(1L);
 
     @Nested
     @DisplayName("인증번호 발송")
     class SendAuthCode {
-        private final String email = member.getEmail().getValue();
-        private final SendAuthCodeCommand command = new SendAuthCodeCommand(email);
-
         @Test
         @DisplayName("이름 + 이메일 + 로그인 아이디에 해당하는 사용자에게 비밀번호 재설정 인증번호를 발송한다")
         void success() {
             // given
-            given(memberRepository.getByEmail(command.email())).willReturn(member);
+            given(memberRepository.getById(member.getId())).willReturn(member);
 
-            final String key = AuthKey.EMAIL.generateAuthKey(email);
+            final String key = AuthKey.EMAIL.generateAuthKey(member.getEmail().getValue());
             final String authCode = "Koddy";
             given(mailAuthenticationProcessor.storeAuthCode(key)).willReturn(authCode);
 
             // when
-            sut.sendAuthCode(command);
+            sut.sendAuthCode(new SendAuthCodeCommand(member.getId()));
 
             // then
             assertAll(
-                    () -> verify(memberRepository, times(1)).getByEmail(command.email()),
+                    () -> verify(memberRepository, times(1)).getById(member.getId()),
                     () -> verify(mailAuthenticationProcessor, times(1)).storeAuthCode(key),
-                    () -> verify(emailSender, times(1)).sendEmailAuthMail(email, authCode),
+                    () -> verify(emailSender, times(1)).sendEmailAuthMail(member.getEmail().getValue(), authCode),
                     () -> assertThat(member.isAuthenticated()).isFalse()
             );
         }
@@ -73,13 +76,13 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
         private final String email = member.getEmail().getValue();
         private final String key = AuthKey.EMAIL.generateAuthKey(email);
         private final String authCode = "Koddy";
-        private final ConfirmAuthCodeCommand command = new ConfirmAuthCodeCommand(email, authCode);
+        private final ConfirmAuthCodeCommand command = new ConfirmAuthCodeCommand(member.getId(), authCode);
 
         @Test
         @DisplayName("인증번호가 일치하지 않으면 사용자 인증에 실패한다")
         void throwExceptionByInvalidAuthCode() {
             // given
-            given(memberRepository.getByEmail(command.email())).willReturn(member);
+            given(memberRepository.getById(command.memberId())).willReturn(member);
             doThrow(new AuthException(INVALID_AUTH_CODE))
                     .when(mailAuthenticationProcessor)
                     .verifyAuthCode(key, command.authCode());
@@ -90,7 +93,7 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
                     .hasMessage(INVALID_AUTH_CODE.getMessage());
 
             assertAll(
-                    () -> verify(memberRepository, times(1)).getByEmail(command.email()),
+                    () -> verify(memberRepository, times(1)).getById(command.memberId()),
                     () -> verify(mailAuthenticationProcessor, times(1)).verifyAuthCode(key, command.authCode()),
                     () -> verify(mailAuthenticationProcessor, times(0)).deleteAuthCode(key)
             );
@@ -100,7 +103,7 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
         @DisplayName("인증번호 검증에 성공한다")
         void success() {
             // given
-            given(memberRepository.getByEmail(command.email())).willReturn(member);
+            given(memberRepository.getById(command.memberId())).willReturn(member);
             doNothing()
                     .when(mailAuthenticationProcessor)
                     .verifyAuthCode(key, command.authCode());
@@ -110,7 +113,7 @@ class EmailAuthenticationUseCaseTest extends UseCaseTest {
 
             // then
             assertAll(
-                    () -> verify(memberRepository, times(1)).getByEmail(command.email()),
+                    () -> verify(memberRepository, times(1)).getById(command.memberId()),
                     () -> verify(mailAuthenticationProcessor, times(1)).verifyAuthCode(key, command.authCode()),
                     () -> verify(mailAuthenticationProcessor, times(1)).deleteAuthCode(key),
                     () -> assertThat(member.isAuthenticated()).isTrue()

--- a/src/test/java/com/koddy/server/auth/presentation/EmailAuthenticationApiControllerTest.java
+++ b/src/test/java/com/koddy/server/auth/presentation/EmailAuthenticationApiControllerTest.java
@@ -2,7 +2,6 @@ package com.koddy.server.auth.presentation;
 
 import com.koddy.server.auth.application.usecase.EmailAuthenticationUseCase;
 import com.koddy.server.auth.presentation.dto.request.ConfirmAuthCodeRequest;
-import com.koddy.server.auth.presentation.dto.request.SendAuthCodeRequest;
 import com.koddy.server.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,7 +14,7 @@ import java.util.UUID;
 
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFactory.body;
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
-import static com.koddy.server.common.utils.RestDocsSpecificationUtils.successDocs;
+import static com.koddy.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -36,22 +35,17 @@ class EmailAuthenticationApiControllerTest extends ControllerTest {
         @DisplayName("이메일 인증번호를 발송한다")
         void success() throws Exception {
             // given
-            final SendAuthCodeRequest request = new SendAuthCodeRequest("sjiwon4491@gmail.com");
             doNothing()
                     .when(emailAuthenticationUseCase)
                     .sendAuthCode(any());
 
             // when
-            final RequestBuilder requestBuilder = post(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL);
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isNoContent())
-                    .andDo(successDocs("MemberApi/EmailAuth/Send", createHttpSpecSnippets(
-                            requestFields(
-                                    body("email", "인증 대상 이메일", true)
-                            )
-                    )));
+                    .andDo(successDocsWithAccessToken("MemberApi/EmailAuth/Send"));
         }
     }
 
@@ -65,20 +59,19 @@ class EmailAuthenticationApiControllerTest extends ControllerTest {
         void success() throws Exception {
             // given
             final String authCode = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 8);
-            final ConfirmAuthCodeRequest request = new ConfirmAuthCodeRequest("sjiwon4491@gmail.com", authCode);
+            final ConfirmAuthCodeRequest request = new ConfirmAuthCodeRequest(authCode);
             doNothing()
                     .when(emailAuthenticationUseCase)
                     .confirmAuthCode(any());
 
             // when
-            final RequestBuilder requestBuilder = post(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, request);
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isNoContent())
-                    .andDo(successDocs("MemberApi/EmailAuth/Confirm", createHttpSpecSnippets(
+                    .andDo(successDocsWithAccessToken("MemberApi/EmailAuth/Confirm", createHttpSpecSnippets(
                             requestFields(
-                                    body("email", "인증 대상 이메일", true),
                                     body("authCode", "인증번호", true)
                             )
                     )));

--- a/src/test/java/com/koddy/server/common/fixture/MenteeFixture.java
+++ b/src/test/java/com/koddy/server/common/fixture/MenteeFixture.java
@@ -111,6 +111,7 @@ public enum MenteeFixture {
     public Mentee toDomain() {
         final Mentee mentee = new Mentee(email, password);
         mentee.complete(name, nationality, profileImageUrl, introduction, languages, interest);
+        mentee.authenticate();
         return mentee;
     }
 }

--- a/src/test/java/com/koddy/server/common/fixture/MentorFixture.java
+++ b/src/test/java/com/koddy/server/common/fixture/MentorFixture.java
@@ -120,12 +120,14 @@ public enum MentorFixture {
     public Mentor toDomain() {
         final Mentor mentor = new Mentor(email, password);
         mentor.complete(name, nationality, profileImageUrl, introduction, languages, universityProfile, meetingUrl, schedules);
+        mentor.authenticate();
         return mentor;
     }
 
     public Mentor toDomain(final List<Schedule> schedules) {
         final Mentor mentor = new Mentor(email, password);
         mentor.complete(name, nationality, profileImageUrl, introduction, languages, universityProfile, meetingUrl, schedules);
+        mentor.authenticate();
         return mentor;
     }
 }

--- a/src/test/java/com/koddy/server/file/presentation/FileManagementApiControllerTest.java
+++ b/src/test/java/com/koddy/server/file/presentation/FileManagementApiControllerTest.java
@@ -1,4 +1,4 @@
-package com.koddy.server.file.presentation.dto;
+package com.koddy.server.file.presentation;
 
 import com.koddy.server.common.ControllerTest;
 import com.koddy.server.file.application.adapter.FileManager;

--- a/src/test/java/com/koddy/server/member/application/usecase/CompleteInformationUseCaseTest.java
+++ b/src/test/java/com/koddy/server/member/application/usecase/CompleteInformationUseCaseTest.java
@@ -3,6 +3,8 @@ package com.koddy.server.member.application.usecase;
 import com.koddy.server.common.UseCaseTest;
 import com.koddy.server.member.application.usecase.command.CompleteMenteeCommand;
 import com.koddy.server.member.application.usecase.command.CompleteMentorCommand;
+import com.koddy.server.member.domain.model.Email;
+import com.koddy.server.member.domain.model.Password;
 import com.koddy.server.member.domain.model.mentee.Mentee;
 import com.koddy.server.member.domain.model.mentor.Mentor;
 import com.koddy.server.member.domain.repository.MenteeRepository;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.koddy.server.common.fixture.MenteeFixture.MENTEE_1;
 import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
+import static com.koddy.server.common.utils.EncryptorFactory.getEncryptor;
 import static com.koddy.server.member.domain.model.Member.EMPTY;
 import static com.koddy.server.member.domain.model.Nationality.ANONYMOUS;
 import static com.koddy.server.member.domain.model.RoleType.MENTEE;
@@ -33,7 +36,10 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
     @DisplayName("Mentor 부가 정보를 기입한다")
     void completeMentor() {
         // given
-        final Mentor mentor = new Mentor(MENTOR_1.getEmail(), MENTOR_1.getPassword()).apply(1L);
+        final Mentor mentor = new Mentor(
+                Email.init("sjiwon4491@gmail.com"),
+                Password.encrypt("Koddy123!@#", getEncryptor())
+        ).apply(1L);
         final CompleteMentorCommand command = new CompleteMentorCommand(
                 mentor.getId(),
                 MENTOR_1.getName(),
@@ -48,7 +54,7 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
         given(mentorRepository.getById(command.mentorId())).willReturn(mentor);
 
         assertAll(
-                () -> assertThat(mentor.getEmail().getValue()).isEqualTo(MENTOR_1.getEmail().getValue()),
+                () -> assertThat(mentor.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                 () -> assertThat(mentor.getPassword()).isNotNull(),
                 () -> assertThat(mentor.getName()).isEqualTo(EMPTY),
                 () -> assertThat(mentor.getNationality()).isEqualTo(ANONYMOUS),
@@ -69,7 +75,7 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
         // then
         assertAll(
                 () -> verify(mentorRepository, times(1)).getById(command.mentorId()),
-                () -> assertThat(mentor.getEmail().getValue()).isEqualTo(MENTOR_1.getEmail().getValue()),
+                () -> assertThat(mentor.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                 () -> assertThat(mentor.getPassword()).isNotNull(),
                 () -> assertThat(mentor.getName()).isEqualTo(command.name()),
                 () -> assertThat(mentor.getNationality()).isEqualTo(command.nationality()),
@@ -89,7 +95,10 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
     @DisplayName("Mentee 부가 정보를 기입한다")
     void completeMentee() {
         // given
-        final Mentee mentee = new Mentee(MENTEE_1.getEmail(), MENTEE_1.getPassword()).apply(1L);
+        final Mentee mentee = new Mentee(
+                Email.init("sjiwon4491@gmail.com"),
+                Password.encrypt("Koddy123!@#", getEncryptor())
+        ).apply(1L);
         final CompleteMenteeCommand command = new CompleteMenteeCommand(
                 mentee.getId(),
                 MENTEE_1.getName(),
@@ -102,7 +111,7 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
         given(menteeRepository.getById(command.menteeId())).willReturn(mentee);
 
         assertAll(
-                () -> assertThat(mentee.getEmail().getValue()).isEqualTo(MENTEE_1.getEmail().getValue()),
+                () -> assertThat(mentee.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                 () -> assertThat(mentee.getPassword()).isNotNull(),
                 () -> assertThat(mentee.getName()).isEqualTo(EMPTY),
                 () -> assertThat(mentee.getNationality()).isEqualTo(ANONYMOUS),
@@ -120,7 +129,7 @@ class CompleteInformationUseCaseTest extends UseCaseTest {
         // then
         assertAll(
                 () -> verify(menteeRepository, times(1)).getById(command.menteeId()),
-                () -> assertThat(mentee.getEmail().getValue()).isEqualTo(MENTEE_1.getEmail().getValue()),
+                () -> assertThat(mentee.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                 () -> assertThat(mentee.getPassword()).isNotNull(),
                 () -> assertThat(mentee.getName()).isEqualTo(command.name()),
                 () -> assertThat(mentee.getNationality()).isEqualTo(command.nationality()),

--- a/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
@@ -38,7 +38,8 @@ class MenteeTest extends ParallelTest {
                     () -> assertThat(mentee.getAvailableLanguages()).isEmpty(),
                     () -> assertThat(mentee.getRoleTypes()).containsExactlyInAnyOrder(MENTEE),
                     () -> assertThat(mentee.getInterest().getSchool()).isEqualTo(EMPTY),
-                    () -> assertThat(mentee.getInterest().getMajor()).isEqualTo(EMPTY)
+                    () -> assertThat(mentee.getInterest().getMajor()).isEqualTo(EMPTY),
+                    () -> assertThat(mentee.isAuthenticated()).isFalse()
             );
 
             /* complete Mentee */

--- a/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentee/MenteeTest.java
@@ -2,6 +2,8 @@ package com.koddy.server.member.domain.model.mentee;
 
 import com.koddy.server.common.ParallelTest;
 import com.koddy.server.global.encrypt.Encryptor;
+import com.koddy.server.member.domain.model.Email;
+import com.koddy.server.member.domain.model.Password;
 import com.koddy.server.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import static com.koddy.server.common.fixture.MenteeFixture.MENTEE_1;
 import static com.koddy.server.common.fixture.MenteeFixture.MENTEE_2;
 import static com.koddy.server.common.utils.EncryptorFactory.getEncryptor;
+import static com.koddy.server.member.domain.model.EmailStatus.INACTIVE;
 import static com.koddy.server.member.domain.model.Member.EMPTY;
 import static com.koddy.server.member.domain.model.Nationality.ANONYMOUS;
 import static com.koddy.server.member.domain.model.RoleType.MENTEE;
@@ -27,9 +30,14 @@ class MenteeTest extends ParallelTest {
         @DisplayName("Mentee를 생성한다")
         void success() {
             /* 초기 Mentee */
-            final Mentee mentee = new Mentee(MENTEE_1.getEmail(), MENTEE_1.getPassword());
+            final Mentee mentee = new Mentee(
+                    Email.init("sjiwon4491@gmail.com"),
+                    Password.encrypt("Koddy123!@#", getEncryptor())
+            );
             assertAll(
-                    () -> assertThat(mentee.getEmail().getValue()).isEqualTo(MENTEE_1.getEmail().getValue()),
+                    () -> assertThat(mentee.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
+                    () -> assertThat(mentee.getEmail().getStatus()).isEqualTo(INACTIVE),
+                    () -> assertThat(mentee.isAuthenticated()).isFalse(),
                     () -> assertThat(mentee.getPassword()).isNotNull(),
                     () -> assertThat(mentee.getName()).isEqualTo(EMPTY),
                     () -> assertThat(mentee.getNationality()).isEqualTo(ANONYMOUS),
@@ -38,8 +46,7 @@ class MenteeTest extends ParallelTest {
                     () -> assertThat(mentee.getAvailableLanguages()).isEmpty(),
                     () -> assertThat(mentee.getRoleTypes()).containsExactlyInAnyOrder(MENTEE),
                     () -> assertThat(mentee.getInterest().getSchool()).isEqualTo(EMPTY),
-                    () -> assertThat(mentee.getInterest().getMajor()).isEqualTo(EMPTY),
-                    () -> assertThat(mentee.isAuthenticated()).isFalse()
+                    () -> assertThat(mentee.getInterest().getMajor()).isEqualTo(EMPTY)
             );
 
             /* complete Mentee */
@@ -52,7 +59,7 @@ class MenteeTest extends ParallelTest {
                     MENTEE_1.getInterest()
             );
             assertAll(
-                    () -> assertThat(mentee.getEmail().getValue()).isEqualTo(MENTEE_1.getEmail().getValue()),
+                    () -> assertThat(mentee.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                     () -> assertThat(mentee.getPassword()).isNotNull(),
                     () -> assertThat(mentee.getName()).isEqualTo(MENTEE_1.getName()),
                     () -> assertThat(mentee.getNationality()).isEqualTo(MENTEE_1.getNationality()),

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
@@ -44,7 +44,8 @@ class MentorTest extends ParallelTest {
                     () -> assertThat(mentor.getUniversityProfile().getMajor()).isEqualTo(EMPTY),
                     () -> assertThat(mentor.getUniversityProfile().getGrade()).isEqualTo(0),
                     () -> assertThat(mentor.getMeetingUrl()).isEqualTo(EMPTY),
-                    () -> assertThat(mentor.getChatTimes()).isEmpty()
+                    () -> assertThat(mentor.getChatTimes()).isEmpty(),
+                    () -> assertThat(mentor.isAuthenticated()).isFalse()
             );
 
             /* complete Mentor */

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/MentorTest.java
@@ -3,6 +3,8 @@ package com.koddy.server.member.domain.model.mentor;
 import com.koddy.server.common.ParallelTest;
 import com.koddy.server.common.fixture.ScheduleFixture;
 import com.koddy.server.global.encrypt.Encryptor;
+import com.koddy.server.member.domain.model.Email;
+import com.koddy.server.member.domain.model.Password;
 import com.koddy.server.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,6 +15,7 @@ import java.util.List;
 import static com.koddy.server.common.fixture.MentorFixture.MENTOR_1;
 import static com.koddy.server.common.fixture.MentorFixture.MENTOR_2;
 import static com.koddy.server.common.utils.EncryptorFactory.getEncryptor;
+import static com.koddy.server.member.domain.model.EmailStatus.INACTIVE;
 import static com.koddy.server.member.domain.model.Member.EMPTY;
 import static com.koddy.server.member.domain.model.Nationality.ANONYMOUS;
 import static com.koddy.server.member.domain.model.RoleType.MENTOR;
@@ -30,9 +33,11 @@ class MentorTest extends ParallelTest {
         @DisplayName("Mentor를 생성한다")
         void success() {
             /* 초기 Mentor */
-            final Mentor mentor = new Mentor(MENTOR_1.getEmail(), MENTOR_1.getPassword());
+            final Mentor mentor = new Mentor(Email.init("sjiwon4491@gmail.com"), Password.encrypt("Koddy123!@#", getEncryptor()));
             assertAll(
-                    () -> assertThat(mentor.getEmail().getValue()).isEqualTo(MENTOR_1.getEmail().getValue()),
+                    () -> assertThat(mentor.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
+                    () -> assertThat(mentor.getEmail().getStatus()).isEqualTo(INACTIVE),
+                    () -> assertThat(mentor.isAuthenticated()).isFalse(),
                     () -> assertThat(mentor.getPassword()).isNotNull(),
                     () -> assertThat(mentor.getName()).isEqualTo(EMPTY),
                     () -> assertThat(mentor.getNationality()).isEqualTo(ANONYMOUS),
@@ -44,8 +49,7 @@ class MentorTest extends ParallelTest {
                     () -> assertThat(mentor.getUniversityProfile().getMajor()).isEqualTo(EMPTY),
                     () -> assertThat(mentor.getUniversityProfile().getGrade()).isEqualTo(0),
                     () -> assertThat(mentor.getMeetingUrl()).isEqualTo(EMPTY),
-                    () -> assertThat(mentor.getChatTimes()).isEmpty(),
-                    () -> assertThat(mentor.isAuthenticated()).isFalse()
+                    () -> assertThat(mentor.getChatTimes()).isEmpty()
             );
 
             /* complete Mentor */
@@ -60,7 +64,7 @@ class MentorTest extends ParallelTest {
                     MENTOR_1.getSchedules()
             );
             assertAll(
-                    () -> assertThat(mentor.getEmail().getValue()).isEqualTo(MENTOR_1.getEmail().getValue()),
+                    () -> assertThat(mentor.getEmail().getValue()).isEqualTo("sjiwon4491@gmail.com"),
                     () -> assertThat(mentor.getPassword()).isNotNull(),
                     () -> assertThat(mentor.getName()).isEqualTo(MENTOR_1.getName()),
                     () -> assertThat(mentor.getNationality()).isEqualTo(MENTOR_1.getNationality()),

--- a/src/test/java/com/koddy/server/member/presentation/CompleteInformationApiControllerTest.java
+++ b/src/test/java/com/koddy/server/member/presentation/CompleteInformationApiControllerTest.java
@@ -21,6 +21,7 @@ import static com.koddy.server.common.utils.RestDocsSpecificationUtils.SnippetFa
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.createHttpSpecSnippets;
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.failureDocsWithAccessToken;
 import static com.koddy.server.common.utils.RestDocsSpecificationUtils.successDocsWithAccessToken;
+import static com.koddy.server.global.exception.GlobalExceptionCode.VALIDATION_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -39,37 +40,56 @@ class CompleteInformationApiControllerTest extends ControllerTest {
     @DisplayName("멘토 부가정보 기입 API [POST /api/members/mentor] - Required AccessToken")
     class CompleteMentor {
         private static final String BASE_URL = "/api/members/mentor";
-        private final CompleteMentorRequest request = new CompleteMentorRequest(
-                MENTOR_1.getName(),
-                MENTOR_1.getNationality(),
-                MENTOR_1.getProfileImageUrl(),
-                MENTOR_1.getIntroduction(),
-                MENTOR_1.getLanguages(),
-                MENTOR_1.getUniversityProfile().getSchool(),
-                MENTOR_1.getUniversityProfile().getMajor(),
-                MENTOR_1.getUniversityProfile().getGrade(),
-                MENTOR_1.getMeetingUrl(),
-                MENTOR_1.getSchedules()
-                        .stream()
-                        .map(it -> new MentorScheduleRequest(it.getDay(), it.getPeriod().getStartTime(), it.getPeriod().getEndTime()))
-                        .toList()
-        );
 
         @Test
-        @DisplayName("멘토가 아니면 멘토 부가정보를 기입할 수 없다")
+        @DisplayName("멘토가 아니면 권한이 없다")
         void throwExceptionByInvalidPermission() throws Exception {
             // given
             mockingToken(true, mentee.getId(), mentee.getRoleTypes());
 
             // when
-            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(true));
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isForbidden())
                     .andExpectAll(getResultMatchersViaExceptionCode(INVALID_PERMISSION))
-                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentor/Failure", createHttpSpecSnippets(
+                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentor/Failure/Case1", createHttpSpecSnippets(
                             requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
+                                    body("name", "이름", true),
+                                    body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
+                                    body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
+                                    body("introduction", "멘토 자기소개", "없으면 null", false),
+                                    body("languages", "사용 가능한 언어", "KOREAN\nENGLISH\nCHINESE\nJAPANESE\nVIETNAMESE", true),
+                                    body("school", "학교", true),
+                                    body("major", "전공", true),
+                                    body("grade", "학년", true),
+                                    body("meetingUrl", "커피챗 링크", true),
+                                    body("schedules", "멘토링 스케줄", true),
+                                    body("schedules[].day", "날짜", "MONDAY\nTUESDAY\nWEDNESDAY\nTHURSDAY\nFRIDAY\nSATURDAY\nSUNDAY", true),
+                                    body("schedules[].startTime", "시작 시간", true),
+                                    body("schedules[].endTime", "종료 시간", true)
+                            )
+                    )));
+        }
+
+        @Test
+        @DisplayName("이메일 인증에 실패하면 부가정보를 기입할 수 없다")
+        void throwExceptionByEmailNotAuthenticated() throws Exception {
+            // given
+            mockingToken(true, mentor.getId(), mentor.getRoleTypes());
+
+            // when
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(false));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isBadRequest())
+                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "이메일 인증을 진행해야 합니다."))
+                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentor/Failure/Case2", createHttpSpecSnippets(
+                            requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
                                     body("name", "이름", true),
                                     body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
                                     body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
@@ -97,13 +117,14 @@ class CompleteInformationApiControllerTest extends ControllerTest {
                     .completeMentor(any());
 
             // when
-            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(true));
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isNoContent())
                     .andDo(successDocsWithAccessToken("MemberApi/Complete/Mentor/Success", createHttpSpecSnippets(
                             requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
                                     body("name", "이름", true),
                                     body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
                                     body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
@@ -121,37 +142,75 @@ class CompleteInformationApiControllerTest extends ControllerTest {
                             )
                     )));
         }
+
+        private CompleteMentorRequest createRequest(final boolean authenticated) {
+            return new CompleteMentorRequest(
+                    authenticated,
+                    MENTOR_1.getName(),
+                    MENTOR_1.getNationality(),
+                    MENTOR_1.getProfileImageUrl(),
+                    MENTOR_1.getIntroduction(),
+                    MENTOR_1.getLanguages(),
+                    MENTOR_1.getUniversityProfile().getSchool(),
+                    MENTOR_1.getUniversityProfile().getMajor(),
+                    MENTOR_1.getUniversityProfile().getGrade(),
+                    MENTOR_1.getMeetingUrl(),
+                    MENTOR_1.getSchedules()
+                            .stream()
+                            .map(it -> new MentorScheduleRequest(it.getDay(), it.getPeriod().getStartTime(), it.getPeriod().getEndTime()))
+                            .toList()
+            );
+        }
     }
 
     @Nested
     @DisplayName("멘티 부가정보 기입 API [POST /api/members/mentee] - Required AccessToken")
     class CompleteMentee {
         private static final String BASE_URL = "/api/members/mentee";
-        private final CompleteMenteeRequest request = new CompleteMenteeRequest(
-                MENTEE_1.getName(),
-                MENTEE_1.getNationality(),
-                MENTEE_1.getProfileImageUrl(),
-                MENTEE_1.getIntroduction(),
-                MENTEE_1.getLanguages(),
-                MENTEE_1.getInterest().getSchool(),
-                MENTEE_1.getInterest().getMajor()
-        );
 
         @Test
-        @DisplayName("멘티가 아니면 멘티 부가정보를 기입할 수 없다")
+        @DisplayName("멘티가 아니면 권한이 없다")
         void throwExceptionByInvalidPermission() throws Exception {
             // given
             mockingToken(true, mentor.getId(), mentor.getRoleTypes());
 
             // when
-            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(true));
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isForbidden())
                     .andExpectAll(getResultMatchersViaExceptionCode(INVALID_PERMISSION))
-                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentee/Failure", createHttpSpecSnippets(
+                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentee/Failure/Case1", createHttpSpecSnippets(
                             requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
+                                    body("name", "이름", true),
+                                    body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
+                                    body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
+                                    body("introduction", "멘티 자기소개", false),
+                                    body("languages", "사용 가능한 언어", "KOREAN\nENGLISH\nCHINESE\nJAPANESE\nVIETNAMESE", true),
+                                    body("interestSchool", "관심있는 학교", true),
+                                    body("interestMajor", "관심있는 전공", true)
+                            )
+                    )));
+        }
+
+        @Test
+        @DisplayName("이메일 인증에 실패하면 부가정보를 기입할 수 없다")
+        void throwExceptionByEmailNotAuthenticated() throws Exception {
+            // given
+            mockingToken(true, mentee.getId(), mentee.getRoleTypes());
+
+            // when
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(false));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isBadRequest())
+                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "이메일 인증을 진행해야 합니다."))
+                    .andDo(failureDocsWithAccessToken("MemberApi/Complete/Mentee/Failure/Case2", createHttpSpecSnippets(
+                            requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
                                     body("name", "이름", true),
                                     body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
                                     body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
@@ -173,13 +232,14 @@ class CompleteInformationApiControllerTest extends ControllerTest {
                     .completeMentor(any());
 
             // when
-            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, request);
+            final RequestBuilder requestBuilder = postWithAccessToken(BASE_URL, createRequest(true));
 
             // then
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isNoContent())
                     .andDo(successDocsWithAccessToken("MemberApi/Complete/Mentee/Success", createHttpSpecSnippets(
                             requestFields(
+                                    body("authenticated", "이메일 인증 결과", true),
                                     body("name", "이름", true),
                                     body("nationality", "국적", "KOREA\nUSA\nJAPAN\nCHINA\nVIETNAM\nOTHERS", true),
                                     body("profileImageUrl", "프로필 이미지 URL", "Presigned Url로 업로드한 프로필 이미지 URL\n->기본 이미지 설정이면 null)", false),
@@ -189,6 +249,19 @@ class CompleteInformationApiControllerTest extends ControllerTest {
                                     body("interestMajor", "관심있는 전공", true)
                             )
                     )));
+        }
+
+        private CompleteMenteeRequest createRequest(final boolean authenticated) {
+            return new CompleteMenteeRequest(
+                    authenticated,
+                    MENTEE_1.getName(),
+                    MENTEE_1.getNationality(),
+                    MENTEE_1.getProfileImageUrl(),
+                    MENTEE_1.getIntroduction(),
+                    MENTEE_1.getLanguages(),
+                    MENTEE_1.getInterest().getSchool(),
+                    MENTEE_1.getInterest().getMajor()
+            );
         }
     }
 }

--- a/src/test/java/com/koddy/server/member/presentation/SimpleSignUpApiControllerTest.java
+++ b/src/test/java/com/koddy/server/member/presentation/SimpleSignUpApiControllerTest.java
@@ -69,40 +69,6 @@ class SimpleSignUpApiControllerTest extends ControllerTest {
         private static final String BASE_URL = "/api/members";
 
         @Test
-        @DisplayName("회원가입 정보가 누락되면 진행할 수 없다")
-        void throwExceptionByInsufficientInfo() throws Exception {
-            // given
-            final SimpleSignUpRequest request1 = new SimpleSignUpRequest("", true, "Helloworld123!@#", MENTOR);
-            final SimpleSignUpRequest request2 = new SimpleSignUpRequest("sjiwon4491@gmail.com", null, "Helloworld123!@#", MENTOR);
-            final SimpleSignUpRequest request3 = new SimpleSignUpRequest("sjiwon4491@gmail.com", true, "", MENTOR);
-            final SimpleSignUpRequest request4 = new SimpleSignUpRequest("sjiwon4491@gmail.com", true, "Helloworld123!@#", null);
-
-            // when
-            final RequestBuilder requestBuilder1 = post(BASE_URL, request1);
-            final RequestBuilder requestBuilder2 = post(BASE_URL, request2);
-            final RequestBuilder requestBuilder3 = post(BASE_URL, request3);
-            final RequestBuilder requestBuilder4 = post(BASE_URL, request4);
-
-            // then
-            mockMvc.perform(requestBuilder1)
-                    .andExpect(status().isBadRequest())
-                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "이메일은 필수입니다."))
-                    .andDo(failureDocs("MemberApi/SignUp/Failure/Case1"));
-            mockMvc.perform(requestBuilder2)
-                    .andExpect(status().isBadRequest())
-                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "이메일 중복 확인 결과는 필수입니다."))
-                    .andDo(failureDocs("MemberApi/SignUp/Failure/Case2"));
-            mockMvc.perform(requestBuilder3)
-                    .andExpect(status().isBadRequest())
-                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "패스워드는 필수입니다."))
-                    .andDo(failureDocs("MemberApi/SignUp/Failure/Case3"));
-            mockMvc.perform(requestBuilder4)
-                    .andExpect(status().isBadRequest())
-                    .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "회원 타입은 필수입니다."))
-                    .andDo(failureDocs("MemberApi/SignUp/Failure/Case4"));
-        }
-
-        @Test
         @DisplayName("이메일 중복 확인을 진행하지 않았으면 회원가입이 불가능하다")
         void throwExceptionByEmailNotChecked() throws Exception {
             // given
@@ -115,7 +81,14 @@ class SimpleSignUpApiControllerTest extends ControllerTest {
             mockMvc.perform(requestBuilder)
                     .andExpect(status().isBadRequest())
                     .andExpectAll(getResultMatchersViaExceptionCode(VALIDATION_ERROR, "이메일 중복 확인을 진행해야 합니다."))
-                    .andDo(failureDocs("MemberApi/SignUp/Failure/Case5"));
+                    .andDo(failureDocs("MemberApi/SignUp/Failure", createHttpSpecSnippets(
+                            requestFields(
+                                    body("email", "이메일", true),
+                                    body("checked", "이메일 중복 체크 결과", true),
+                                    body("password", "비밀번호", true),
+                                    body("type", "사용자 타입", "MENTOR / MENTEE", true)
+                            )
+                    )));
         }
 
         @Test

--- a/src/test/java/com/koddy/server/member/presentation/UpdateMenteeInfoApiControllerTest.java
+++ b/src/test/java/com/koddy/server/member/presentation/UpdateMenteeInfoApiControllerTest.java
@@ -6,7 +6,7 @@ import com.koddy.server.member.application.usecase.UpdateMenteeInfoUseCase;
 import com.koddy.server.member.domain.model.mentee.Mentee;
 import com.koddy.server.member.domain.model.mentor.Mentor;
 import com.koddy.server.member.presentation.dto.request.UpdateMenteeBasicInfoRequest;
-import com.koddy.server.member.presentation.dto.request.UpdateMentorPasswordRequest;
+import com.koddy.server.member.presentation.dto.request.UpdateMenteePasswordRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -112,7 +112,7 @@ class UpdateMenteeInfoApiControllerTest extends ControllerTest {
     @DisplayName("멘티 비밀번호 수정 API [PATCH /api/mentees/me/password] - Required AccessToken")
     class UpdatePassword {
         private static final String BASE_URL = "/api/mentees/me/password";
-        private final UpdateMentorPasswordRequest request = new UpdateMentorPasswordRequest(
+        private final UpdateMenteePasswordRequest request = new UpdateMenteePasswordRequest(
                 "current",
                 "update"
         );

--- a/src/test/java/com/koddy/server/member/utils/validator/ValidMailAuthenticatedValidatorTest.java
+++ b/src/test/java/com/koddy/server/member/utils/validator/ValidMailAuthenticatedValidatorTest.java
@@ -1,0 +1,59 @@
+package com.koddy.server.member.utils.validator;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("Member -> ValidMailAuthenticatedValidator 테스트")
+class ValidMailAuthenticatedValidatorTest {
+    private final ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+    private final ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+    private final ValidMailAuthenticatedValidator sut = new ValidMailAuthenticatedValidator();
+
+    @Test
+    @DisplayName("이메일 인증 결과를 null로 보내면 Validator를 통과할 수 없다")
+    void nullAuthenticated() {
+        // given
+        given(context.buildConstraintViolationWithTemplate(anyString())).willReturn(builder);
+        given(builder.addConstraintViolation()).willReturn(context);
+
+        // when
+        final boolean actual = sut.isValid(null, context);
+
+        // then
+        assertAll(
+                () -> verify(context, times(1)).disableDefaultConstraintViolation(),
+                () -> verify(context, times(1)).buildConstraintViolationWithTemplate("이메일 인증 결과는 필수입니다."),
+                () -> verify(builder, times(1)).addConstraintViolation(),
+                () -> assertThat(actual).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 하지 않았으면 Validator를 통과할 수 없다")
+    void unAuthenticated() {
+        // when
+        final boolean actual = sut.isValid(false, context);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 진행했으면 Validator를 통과한다")
+    void authenticated() {
+        // when
+        final boolean actual = sut.isValid(true, context);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+}


### PR DESCRIPTION
## 📄 Summary

> Close #25

- 이메일 인증번호 확인 시 사용자 계정 활성화
- 이메일 인증 관련 API 스펙 수정
  - 기존 = email 받아서 처리
  - 개선 = 토큰을 통한 ID 추출
    - 부가정보 기입은 간편 회원가입 이후이므로 토큰 필요
- 부가정보 기입시 이메일 인증 결과(Boolean)도 추가해서 요청