### PR TITLE
[Feature] 커피챗 예약 관련 도메인을 설계한다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.springframework.security:spring-security-crypto")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     // Data

--- a/docker/docker-compose-dev-persistence.yml
+++ b/docker/docker-compose-dev-persistence.yml
@@ -9,7 +9,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "1234"
       MYSQL_DATABASE: "koddy"
-      TZ: "UTC"
+      TZ: "Asia/Seoul"
       LANG: "C.UTF_8"
     command:
       - --character-set-server=utf8mb4

--- a/src/main/java/com/koddy/server/coffeechat/domain/model/CoffeeChat.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/model/CoffeeChat.java
@@ -1,0 +1,93 @@
+package com.koddy.server.coffeechat.domain.model;
+
+import com.koddy.server.global.base.BaseEntity;
+import com.koddy.server.member.domain.model.Member;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.koddy.server.coffeechat.domain.model.CoffeeChatStatus.APPLY;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "coffee_chat")
+public class CoffeeChat extends BaseEntity<CoffeeChat> {
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "year", column = @Column(name = "start_year", nullable = false)),
+            @AttributeOverride(name = "month", column = @Column(name = "start_month", nullable = false)),
+            @AttributeOverride(name = "day", column = @Column(name = "start_day", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "start_time", nullable = false))
+    })
+    private Reservation start;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "year", column = @Column(name = "end_year", nullable = false)),
+            @AttributeOverride(name = "month", column = @Column(name = "end_month", nullable = false)),
+            @AttributeOverride(name = "day", column = @Column(name = "end_day", nullable = false)),
+            @AttributeOverride(name = "time", column = @Column(name = "end_time", nullable = false))
+    })
+    private Reservation end;
+
+    @Embedded
+    private Strategy strategy;
+
+    @Lob
+    @Column(name = "apply_reason", nullable = false, columnDefinition = "TEXT")
+    private String applyReason;
+
+    @Enumerated(STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "VARCHAR(30)")
+    private CoffeeChatStatus status;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "applier_id", referencedColumnName = "id", nullable = false)
+    private Member<?> applier;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "target_id", referencedColumnName = "id", nullable = false)
+    private Member<?> target;
+
+    private CoffeeChat(
+            final Member<?> applier,
+            final Member<?> target,
+            final Reservation start,
+            final Reservation end,
+            final Strategy strategy,
+            final String applyReason,
+            final CoffeeChatStatus status
+    ) {
+        this.applier = applier;
+        this.target = target;
+        this.start = start;
+        this.end = end;
+        this.strategy = strategy;
+        this.applyReason = applyReason;
+        this.status = status;
+    }
+
+    public static CoffeeChat apply(
+            final Member<?> applier,
+            final Member<?> target,
+            final Reservation start,
+            final Reservation end,
+            final Strategy strategy,
+            final String applyReason
+    ) {
+        return new CoffeeChat(applier, target, start, end, strategy, applyReason, APPLY);
+    }
+}

--- a/src/main/java/com/koddy/server/coffeechat/domain/model/CoffeeChatStatus.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/model/CoffeeChatStatus.java
@@ -1,0 +1,17 @@
+package com.koddy.server.coffeechat.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CoffeeChatStatus {
+    APPLY("신청"),
+    APPROVE("수락"),
+    REJECT("거절"),
+    COMPLETE("완료"),
+    CANCEL("취소"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/koddy/server/coffeechat/domain/model/Reservation.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/model/Reservation.java
@@ -1,0 +1,35 @@
+package com.koddy.server.coffeechat.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Embeddable
+public class Reservation {
+    @Column(name = "year", nullable = false)
+    private int year;
+
+    @Column(name = "month", nullable = false)
+    private int month;
+
+    @Column(name = "day", nullable = false)
+    private int day;
+
+    @Column(name = "time", nullable = false)
+    private LocalTime time;
+
+    public Reservation(final LocalDateTime target) {
+        this.year = target.getYear();
+        this.month = target.getMonthValue();
+        this.day = target.getDayOfMonth();
+        this.time = target.toLocalTime();
+    }
+}

--- a/src/main/java/com/koddy/server/coffeechat/domain/model/Reservation.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/model/Reservation.java
@@ -1,6 +1,5 @@
 package com.koddy.server.coffeechat.domain.model;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,16 +13,9 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable
 public class Reservation {
-    @Column(name = "year", nullable = false)
     private int year;
-
-    @Column(name = "month", nullable = false)
     private int month;
-
-    @Column(name = "day", nullable = false)
     private int day;
-
-    @Column(name = "time", nullable = false)
     private LocalTime time;
 
     public Reservation(final LocalDateTime target) {

--- a/src/main/java/com/koddy/server/coffeechat/domain/model/Strategy.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/model/Strategy.java
@@ -1,0 +1,41 @@
+package com.koddy.server.coffeechat.domain.model;
+
+import com.koddy.server.global.encrypt.Encryptor;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Lob;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Embeddable
+public class Strategy {
+    @Enumerated(STRING)
+    @Column(name = "chat_type", nullable = false, columnDefinition = "VARCHAR(30)")
+    private Type type;
+
+    @Lob
+    @Column(name = "chat_type_value", nullable = false, columnDefinition = "TEXT")
+    private String value;
+
+    private Strategy(final Type type, final String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public static Strategy of(final Type type, final String value, final Encryptor encryptor) {
+        return new Strategy(type, encryptor.symmetricEncrypt(value));
+    }
+
+    public enum Type {
+        LINK,
+        KAKAO_ID,
+        LINK_ID,
+        WECHAT_ID
+    }
+}

--- a/src/main/java/com/koddy/server/coffeechat/domain/repository/CoffeeChatRepository.java
+++ b/src/main/java/com/koddy/server/coffeechat/domain/repository/CoffeeChatRepository.java
@@ -1,0 +1,7 @@
+package com.koddy.server.coffeechat.domain.repository;
+
+import com.koddy.server.coffeechat.domain.model.CoffeeChat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
+}

--- a/src/main/java/com/koddy/server/coffeechat/exception/CoffeeChatException.java
+++ b/src/main/java/com/koddy/server/coffeechat/exception/CoffeeChatException.java
@@ -1,0 +1,18 @@
+package com.koddy.server.coffeechat.exception;
+
+import com.koddy.server.global.base.KoddyException;
+import com.koddy.server.global.base.KoddyExceptionCode;
+
+public class CoffeeChatException extends KoddyException {
+    private final CoffeeChatExceptionCode code;
+
+    public CoffeeChatException(final CoffeeChatExceptionCode code) {
+        super(code);
+        this.code = code;
+    }
+
+    @Override
+    public KoddyExceptionCode getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/koddy/server/coffeechat/exception/CoffeeChatExceptionCode.java
+++ b/src/main/java/com/koddy/server/coffeechat/exception/CoffeeChatExceptionCode.java
@@ -1,0 +1,16 @@
+package com.koddy.server.coffeechat.exception;
+
+import com.koddy.server.global.base.KoddyExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CoffeeChatExceptionCode implements KoddyExceptionCode {
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/koddy/server/global/base/BaseEntity.java
+++ b/src/main/java/com/koddy/server/global/base/BaseEntity.java
@@ -9,7 +9,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -21,21 +21,21 @@ public abstract class BaseEntity<T> {
     private Long id;
 
     @Column(name = "created_at", updatable = false)
-    private ZonedDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "last_modified_at")
-    private ZonedDateTime lastModifiedAt;
+    private LocalDateTime lastModifiedAt;
 
     @PrePersist
     void prePersist() {
-        final ZonedDateTime now = ZonedDateTime.now();
+        final LocalDateTime now = LocalDateTime.now();
         createdAt = now;
         lastModifiedAt = now;
     }
 
     @PreUpdate
     void preUpdate() {
-        lastModifiedAt = ZonedDateTime.now();
+        lastModifiedAt = LocalDateTime.now();
     }
 
     @SuppressWarnings("unchecked")
@@ -47,7 +47,7 @@ public abstract class BaseEntity<T> {
 
     @SuppressWarnings("unchecked")
     @VisibleForTesting
-    public T apply(final long id, final ZonedDateTime now) {
+    public T apply(final long id, final LocalDateTime now) {
         this.id = id;
         this.createdAt = now;
         this.lastModifiedAt = now;

--- a/src/main/java/com/koddy/server/global/config/EncryptorConfig.java
+++ b/src/main/java/com/koddy/server/global/config/EncryptorConfig.java
@@ -1,0 +1,26 @@
+package com.koddy.server.global.config;
+
+import com.koddy.server.global.config.properties.EncryptorProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class EncryptorConfig {
+    private final EncryptorProperties encryptorProperties;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public BytesEncryptor bytesEncryptor() {
+        return new AesBytesEncryptor(encryptorProperties.secretKey(), encryptorProperties.salt());
+    }
+}

--- a/src/main/java/com/koddy/server/global/config/TimeZoneConfig.java
+++ b/src/main/java/com/koddy/server/global/config/TimeZoneConfig.java
@@ -9,6 +9,6 @@ import java.util.TimeZone;
 public class TimeZoneConfig {
     @PostConstruct
     public void init() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/koddy/server/global/config/properties/EncryptorProperties.java
+++ b/src/main/java/com/koddy/server/global/config/properties/EncryptorProperties.java
@@ -1,0 +1,10 @@
+package com.koddy.server.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "encrypt")
+public record EncryptorProperties(
+        String secretKey,
+        String salt
+) {
+}

--- a/src/main/java/com/koddy/server/global/encrypt/DefaultEncryptor.java
+++ b/src/main/java/com/koddy/server/global/encrypt/DefaultEncryptor.java
@@ -1,0 +1,39 @@
+package com.koddy.server.global.encrypt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Component
+@RequiredArgsConstructor
+public class DefaultEncryptor implements Encryptor {
+    private final PasswordEncoder passwordEncoder;
+    private final BytesEncryptor bytesEncryptor;
+
+    @Override
+    public String hashEncrypt(final String value) {
+        return passwordEncoder.encode(value);
+    }
+
+    @Override
+    public boolean isHashMatch(final String rawValue, final String encodedValue) {
+        return passwordEncoder.matches(rawValue, encodedValue);
+    }
+
+    @Override
+    public String symmetricEncrypt(final String value) {
+        final byte[] encryptedBytes = bytesEncryptor.encrypt(value.getBytes(UTF_8));
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    @Override
+    public String symmetricDecrypt(final String value) {
+        final byte[] decryptedBytes = bytesEncryptor.decrypt(Base64.getDecoder().decode(value));
+        return new String(decryptedBytes, UTF_8);
+    }
+}

--- a/src/main/java/com/koddy/server/global/encrypt/Encryptor.java
+++ b/src/main/java/com/koddy/server/global/encrypt/Encryptor.java
@@ -1,0 +1,11 @@
+package com.koddy.server.global.encrypt;
+
+public interface Encryptor {
+    String hashEncrypt(final String value);
+
+    boolean isHashMatch(final String rawValue, final String encodedValue);
+
+    String symmetricEncrypt(final String value);
+
+    String symmetricDecrypt(final String value);
+}

--- a/src/main/java/com/koddy/server/member/domain/model/mentor/Day.java
+++ b/src/main/java/com/koddy/server/member/domain/model/mentor/Day.java
@@ -3,6 +3,8 @@ package com.koddy.server.member.domain.model.mentor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @RequiredArgsConstructor
 public enum Day {
@@ -16,4 +18,16 @@ public enum Day {
 
     private final String kor;
     private final String eng;
+
+    public static Day of(final int year, final int month, final int day) {
+        return switch (LocalDate.of(year, month, day).getDayOfWeek()) {
+            case MONDAY -> MON;
+            case TUESDAY -> TUE;
+            case WEDNESDAY -> WED;
+            case THURSDAY -> THU;
+            case FRIDAY -> FRI;
+            case SATURDAY -> SAT;
+            case SUNDAY -> SUN;
+        };
+    }
 }

--- a/src/main/java/com/koddy/server/member/domain/repository/AvailableLanguageRepository.java
+++ b/src/main/java/com/koddy/server/member/domain/repository/AvailableLanguageRepository.java
@@ -1,0 +1,7 @@
+package com.koddy.server.member.domain.repository;
+
+import com.koddy.server.member.domain.model.AvailableLanguage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AvailableLanguageRepository extends JpaRepository<AvailableLanguage, Long> {
+}

--- a/src/main/java/com/koddy/server/member/domain/repository/ChatTimeRepository.java
+++ b/src/main/java/com/koddy/server/member/domain/repository/ChatTimeRepository.java
@@ -1,0 +1,7 @@
+package com.koddy.server.member.domain.repository;
+
+import com.koddy.server.member.domain.model.mentor.ChatTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatTimeRepository extends JpaRepository<ChatTime, Long> {
+}

--- a/src/main/java/com/koddy/server/member/domain/repository/RoleRepository.java
+++ b/src/main/java/com/koddy/server/member/domain/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package com.koddy.server.member.domain.repository;
+
+import com.koddy.server.member.domain.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ management:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/koddy?autoReconnect=true&characterEncoding=UTF8&serverTimeZone=UTC
+    url: jdbc:mysql://localhost:3306/koddy?autoReconnect=true&characterEncoding=UTF8&serverTimeZone=Asia/Seoul
     username: root
     password: 1234
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,8 +76,12 @@ oauth2:
 cors:
   allowed-origin-patterns: http://localhost:3000
 
+encrypt:
+  secret-key: 26f01335335d279cc9fbfa1cb2b73819111460fa21905f689763946b6bf4beee
+  salt: 0b7a3890901fe0c61f14f26ab87189211922d4a294f9619bf70606618d6044f3 # Even Hex Number
+
 jwt:
-  secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb # 테스트용 Secret Key
+  secret-key: 2da7acad220ffe59e6943c826ec1fcf879a4339521ff5837fa92aab485e94bcb
   access-token-validity-seconds: 7200
   refresh-token-validity-seconds: 1209600
 

--- a/src/main/resources/db/migration/V4__add_coffee_chat.sql
+++ b/src/main/resources/db/migration/V4__add_coffee_chat.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS coffee_chat
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    applier_id       BIGINT      NOT NULL,
+    target_id        BIGINT      NOT NULL,
+    start_year       INT         NOT NULL,
+    start_month      INT         NOT NULL,
+    start_day        INT         NOT NULL,
+    start_time       TIME        NOT NULL,
+    end_year         INT         NOT NULL,
+    end_month        INT         NOT NULL,
+    end_day          INT         NOT NULL,
+    end_time         TIME        NOT NULL,
+    chat_type        VARCHAR(30) NOT NULL,
+    chat_type_value  TEXT        NOT NULL,
+    apply_reason     TEXT        NOT NULL,
+    status           VARCHAR(30) NOT NULL,
+    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_modified_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+ALTER TABLE coffee_chat
+    ADD CONSTRAINT fk_coffee_chat_applier_id_from_member
+        FOREIGN KEY (applier_id)
+            REFERENCES member (id);
+
+ALTER TABLE coffee_chat
+    ADD CONSTRAINT fk_coffee_chat_target_id_from_member
+        FOREIGN KEY (target_id)
+            REFERENCES member (id);

--- a/src/test/java/com/koddy/server/coffeechat/domain/model/StrategyTest.java
+++ b/src/test/java/com/koddy/server/coffeechat/domain/model/StrategyTest.java
@@ -1,0 +1,45 @@
+package com.koddy.server.coffeechat.domain.model;
+
+import com.koddy.server.common.ParallelTest;
+import com.koddy.server.global.encrypt.Encryptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.koddy.server.coffeechat.domain.model.Strategy.Type.KAKAO_ID;
+import static com.koddy.server.coffeechat.domain.model.Strategy.Type.LINK;
+import static com.koddy.server.coffeechat.domain.model.Strategy.Type.LINK_ID;
+import static com.koddy.server.coffeechat.domain.model.Strategy.Type.WECHAT_ID;
+import static com.koddy.server.common.utils.EncryptorFactory.getEncryptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("CoffeeChat -> 도메인 [StrategyTest] 테스트")
+class StrategyTest extends ParallelTest {
+    private final Encryptor encryptor = getEncryptor();
+
+    @Test
+    @DisplayName("미팅 방식을 결정한다")
+    void construct() {
+        // given
+        final String link = "https://google.com";
+        final String messangerId = "sjiwon";
+
+        // when
+        final Strategy strategyA = Strategy.of(LINK, link, encryptor);
+        final Strategy strategyB = Strategy.of(KAKAO_ID, messangerId, encryptor);
+        final Strategy strategyC = Strategy.of(LINK_ID, messangerId, encryptor);
+        final Strategy strategyD = Strategy.of(WECHAT_ID, messangerId, encryptor);
+
+        // then
+        assertAll(
+                () -> assertThat(strategyA.getType()).isEqualTo(LINK),
+                () -> assertThat(encryptor.symmetricDecrypt(strategyA.getValue())).isEqualTo(link),
+                () -> assertThat(strategyB.getType()).isEqualTo(KAKAO_ID),
+                () -> assertThat(encryptor.symmetricDecrypt(strategyB.getValue())).isEqualTo(messangerId),
+                () -> assertThat(strategyC.getType()).isEqualTo(LINK_ID),
+                () -> assertThat(encryptor.symmetricDecrypt(strategyC.getValue())).isEqualTo(messangerId),
+                () -> assertThat(strategyD.getType()).isEqualTo(WECHAT_ID),
+                () -> assertThat(encryptor.symmetricDecrypt(strategyD.getValue())).isEqualTo(messangerId)
+        );
+    }
+}

--- a/src/test/java/com/koddy/server/common/mock/FakeEncryptor.java
+++ b/src/test/java/com/koddy/server/common/mock/FakeEncryptor.java
@@ -1,0 +1,27 @@
+package com.koddy.server.common.mock;
+
+import com.koddy.server.global.encrypt.Encryptor;
+
+public class FakeEncryptor implements Encryptor {
+    private static final String DUMMY = "_koddy";
+
+    @Override
+    public String hashEncrypt(final String value) {
+        return value + DUMMY;
+    }
+
+    @Override
+    public boolean isHashMatch(final String rawValue, final String encodedValue) {
+        return encodedValue.replace(DUMMY, "").equals(rawValue);
+    }
+
+    @Override
+    public String symmetricEncrypt(final String value) {
+        return value + DUMMY;
+    }
+
+    @Override
+    public String symmetricDecrypt(final String value) {
+        return value.replace(DUMMY, "");
+    }
+}

--- a/src/test/java/com/koddy/server/common/utils/EncryptorFactory.java
+++ b/src/test/java/com/koddy/server/common/utils/EncryptorFactory.java
@@ -1,0 +1,45 @@
+package com.koddy.server.common.utils;
+
+import com.koddy.server.common.mock.FakeEncryptor;
+import com.koddy.server.global.encrypt.Encryptor;
+
+import java.security.SecureRandom;
+
+public class EncryptorFactory {
+    private static final Encryptor ENCRYPTOR = new FakeEncryptor();
+
+    public static Encryptor getEncryptor() {
+        return ENCRYPTOR;
+    }
+
+    public static void main(final String[] args) {
+        password();
+        salt();
+    }
+
+    private static void password() {
+        final String characters = "0123456789abcdef";
+
+        final SecureRandom random = new SecureRandom();
+        final StringBuilder sb = new StringBuilder(64);
+
+        for (int i = 0; i < 64; i++) {
+            final int randomIndex = random.nextInt(characters.length());
+            sb.append(characters.charAt(randomIndex));
+        }
+
+        System.out.println("Password = " + sb);
+    }
+
+    private static void salt() {
+        final SecureRandom random = new SecureRandom();
+        final byte[] salt = new byte[32];
+        random.nextBytes(salt);
+
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : salt) {
+            sb.append(String.format("%02x", b));
+        }
+        System.out.println("Salt = " + sb);
+    }
+}

--- a/src/test/java/com/koddy/server/member/domain/model/EmailTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/EmailTest.java
@@ -11,7 +11,7 @@ import static com.koddy.server.member.exception.MemberExceptionCode.INVALID_EMAI
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@DisplayName("Member -> 도메인 [Email VO] 테스트")
+@DisplayName("Member -> 도메인 [Email] 테스트")
 class EmailTest extends ParallelTest {
     @Nested
     @DisplayName("Email 생성")

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/DayTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/DayTest.java
@@ -1,13 +1,14 @@
 package com.koddy.server.member.domain.model.mentor;
 
+import com.koddy.server.common.ParallelTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Member/Mentor -> 도메인 [Day VO] 테스트")
-class DayTest {
+@DisplayName("Member/Mentor -> 도메인 [Day] 테스트")
+class DayTest extends ParallelTest {
     @ParameterizedTest
     @CsvSource(
             value = {

--- a/src/test/java/com/koddy/server/member/domain/model/mentor/DayTest.java
+++ b/src/test/java/com/koddy/server/member/domain/model/mentor/DayTest.java
@@ -1,0 +1,28 @@
+package com.koddy.server.member.domain.model.mentor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member/Mentor -> 도메인 [Day VO] 테스트")
+class DayTest {
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "2023:12:25:MON",
+                    "2023:12:26:TUE",
+                    "2023:12:27:WED",
+                    "2023:12:28:THU",
+                    "2023:12:29:FRI",
+                    "2023:12:30:SAT",
+                    "2023:12:31:SUN",
+            },
+            delimiter = ':'
+    )
+    @DisplayName("Year/Month/Day 정보를 기준으로 Day를 가져온다")
+    void getDay(final int year, final int month, final int day, final Day expected) {
+        assertThat(Day.of(year, month, day)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## 📄 Summary

> Close #29

- WAS, DB Timezone KST로 재수정
  - 서비스를 이용하는 멘토는 모두 Korea 기준
  - UTC 기준으로 관리하면 멘토 스케줄 타임에 따라 기존 [Day, Start, End] -> Day 자체도 세분화(startDay, endDay)해서 관리하도록 수정
  - 그래서 Client 요청 & 서버 관리 시간은 전부 KST + 시간 관련 응답에 대해서는 Client's Timezone에 따라 변환해서 표현
- 커피챗 예약 관련 도메인 구현
  - 미팅에 관한 세부 사항(회의 링크, 메신저 ID)는 암호화해서 저장 -> `AES 기반` 양방향 암호화